### PR TITLE
Fix/revert to python3.7

### DIFF
--- a/earthmover/graph.py
+++ b/earthmover/graph.py
@@ -48,7 +48,8 @@ class Graph(nx.DiGraph):
         :param ref:
         :return:
         """
-        if _node := self.nodes.get(ref):
+        _node = self.nodes.get(ref)
+        if _node:
             return _node['data']
         else:
             return None

--- a/earthmover/nodes/transformation.py
+++ b/earthmover/nodes/transformation.py
@@ -26,9 +26,12 @@ class Transformation(Node):
             self.operations.append(operation)
 
             # Sources are defined in a 'source_list' or 'source' class attribute, but never both.
-            if _source_list := operation.__dict__.get('source_list'):
+            _source_list = operation.__dict__.get('source_list')
+            _source = operation.__dict__.get('source')
+
+            if _source_list:
                 self.sources.update(_source_list)
-            elif _source := operation.__dict__.get('source'):
+            elif _source:
                 self.sources.add(_source)
 
         # Sources are saved as an attribute to build network edges in `Earthmover.graph`.

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -445,11 +445,14 @@ class MapValuesOperation(Operation):
         super().compile()
 
         #
-        if _column := self.config.get('column'):
+        _column = self.config.get('column')
+        _columns = self.config.get('columns')
+
+        if _column:
             self.error_handler.assert_key_type_is(self.config, 'column', str)
             self.columns_list = [_column]
 
-        elif _columns := self.config.get('columns'):
+        elif _columns:
             self.error_handler.assert_key_type_is(self.config, 'columns', list)
             self.columns_list = _columns
 
@@ -460,11 +463,14 @@ class MapValuesOperation(Operation):
             raise
 
         #
-        if _mapping := self.config.get('mapping'):
+        _mapping = self.config.get('mapping')
+        _map_file = self.config.get('map_file')
+
+        if _mapping:
             self.error_handler.assert_key_type_is(self.config, "mapping", dict)
             self.mapping = _mapping
 
-        elif _map_file := self.config.get('map_file'):
+        elif _map_file:
             self.error_handler.assert_key_type_is(self.config, "map_file", str)
             self.map_file = _map_file
             self.mapping = self._read_map_file(_map_file)
@@ -558,11 +564,14 @@ class DateFormatOperation(Operation):
         self.to_format = self.config['to_format']
 
         #
-        if _column := self.config.get('column'):
+        _column = self.config.get('column')
+        _columns = self.config.get('columns')
+
+        if _column:
             self.error_handler.assert_key_type_is(self.config, 'column', str)
             self.columns_list = [_column]
 
-        elif _columns := self.config.get('columns'):
+        elif _columns:
             self.error_handler.assert_key_type_is(self.config, 'columns', list)
             self.columns_list = _columns
 

--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -45,11 +45,14 @@ class JoinOperation(Operation):
             self.error_handler.throw("must define `left_key` or `left_keys`")
             raise
 
-        if _key := self.config.get('left_key'):
+        _key = self.config.get('left_key')
+        _keys = self.config.get('left_keys')
+
+        if _key:
             self.error_handler.assert_key_type_is(self.config, 'left_key', str)
             self.left_keys = [_key]
 
-        elif _keys := self.config.get('left_keys'):
+        elif _keys:
             self.error_handler.assert_key_type_is(self.config, 'left_keys', list)
             self.left_keys = _keys
         else:
@@ -64,11 +67,14 @@ class JoinOperation(Operation):
             self.error_handler.throw("must define `right_key` or `right_keys`")
             raise
 
-        if _key := self.config.get('right_key'):
+        _key = self.config.get('right_key')
+        _keys = self.config.get('right_keys')
+
+        if _key:
             self.error_handler.assert_key_type_is(self.config, 'right_key', str)
             self.right_keys = [_key]
 
-        elif _keys := self.config.get('right_keys'):
+        elif _keys:
             self.error_handler.assert_key_type_is(self.config, 'right_keys', list)
             self.right_keys = _keys
         else:
@@ -100,19 +106,25 @@ class JoinOperation(Operation):
 
 
         # Check left columns
-        if _keep_cols := self.config.get('left_keep_columns'):
+        _keep_cols = self.config.get('left_keep_columns')
+        _drop_cols = self.config.get('left_drop_columns')
+
+        if _keep_cols:
             self.error_handler.assert_key_type_is(self.config, 'left_keep_columns', list)
             self.left_keep_cols = _keep_cols
-        elif _drop_cols := self.config.get('left_drop_columns'):
+        elif _drop_cols:
             self.error_handler.assert_key_type_is(self.config, 'left_drop_columns', list)
             self.left_drop_cols = _drop_cols
 
 
         # Check right columns
-        if _keep_cols := self.config.get('right_keep_columns'):
+        _keep_cols = self.config.get('right_keep_columns')
+        _drop_cols = self.config.get('right_drop_columns')
+
+        if _keep_cols:
             self.error_handler.assert_key_type_is(self.config, 'right_keep_columns', list)
             self.right_keep_cols = _keep_cols
-        elif _drop_cols := self.config.get('right_drop_columns'):
+        elif _drop_cols:
             self.error_handler.assert_key_type_is(self.config, 'right_drop_columns', list)
             self.right_drop_cols = _drop_cols
 

--- a/earthmover/operations/groupby.py
+++ b/earthmover/operations/groupby.py
@@ -246,7 +246,8 @@ class GroupByOperation(Operation):
                         f"aggregation function `{_agg_type}`({_col}) refers to a column {_col} which does not exist"
                     )
 
-            if not (agg_lambda := self._get_agg_lambda(_agg_type, _col, _sep)):
+            agg_lambda = self._get_agg_lambda(_agg_type, _col, _sep)
+            if not agg_lambda:
                 self.error_handler.throw(
                     f"invalid aggregation function `{_agg_type}` in `group_by` operation"
                 )

--- a/earthmover/operations/row.py
+++ b/earthmover/operations/row.py
@@ -21,11 +21,14 @@ class DistinctRowsOperation(Operation):
         super().compile()
 
         #
-        if _column := self.config.get('column'):
+        _column = self.config.get('column')
+        _columns = self.config.get('columns')
+
+        if _column:
             self.error_handler.assert_key_type_is(self.config, 'column', str)
             self.columns_list = [_column]
 
-        elif _columns := self.config.get('columns'):
+        elif _columns:
             self.error_handler.assert_key_type_is(self.config, 'columns', list)
             self.columns_list = _columns
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wheel
 aiohttp>=3.8.1
 dask[dataframe]>=2022.2.0
-Jinja2>=3.1.2
+Jinja2>=2.11.3
 matplotlib>=3.2.2
 networkx>=2.6.3
 pandas>=1.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 wheel
-aiohttp==3.8.1
-dask[dataframe]==2022.9.0
-Jinja2==3.1.2
-matplotlib==3.5.3
-networkx==2.8.6
-pandas==1.4.4
-requests==2.28.1
-setuptools==44.0.0
+aiohttp>=3.8.1
+dask[dataframe]>=2022.2.0
+Jinja2>=3.1.2
+matplotlib>=3.2.2
+networkx>=2.6.3
+pandas>=1.3.5
+requests>=2.23.0
+setuptools>=44.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup (
     version = VERSION,
     packages = setuptools.find_namespace_packages(include=['earthmover', 'earthmover.*']),
     include_package_data=True,
-    # install_requires = all_reqs,
+    install_requires = all_reqs,
     python_requires = '>=3',
     entry_points = '''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup (
     version = VERSION,
     packages = setuptools.find_namespace_packages(include=['earthmover', 'earthmover.*']),
     include_package_data=True,
-    install_requires = all_reqs,
+    # install_requires = all_reqs,
     python_requires = '>=3',
     entry_points = '''
         [console_scripts]


### PR DESCRIPTION
This PR removes all instances of the Python 3.8 walrus operator, and it downgrades certain packages to be better aligned with their default versions on Google Colab (using Python 3.7.15). It also loosens package versioning requirements such that a user can run Earthmover with more recent package versions, instead of specific versions.