### PR TITLE
Feature/hide yaml line annotations

### DIFF
--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -116,8 +116,6 @@ class Earthmover:
         # sources:
         self.error_handler.assert_key_exists_and_type_is(self.user_configs, 'sources', dict)
         for name, config in self.user_configs['sources'].items():
-            if name == "__line__":
-                continue  # skip YAML line annotations
 
             node = Source(name, config, earthmover=self)
             self.graph.add_node(f"$sources.{name}", data=node)
@@ -127,8 +125,6 @@ class Earthmover:
             self.error_handler.assert_key_type_is(self.user_configs, 'transformations', dict)
 
             for name, config in self.user_configs['transformations'].items():
-                if name == "__line__":
-                    continue  # skip YAML line annotations
 
                 node = Transformation(name, config, earthmover=self)
                 self.graph.add_node(f"$transformations.{name}", data=node)
@@ -146,8 +142,6 @@ class Earthmover:
         # destinations:
         self.error_handler.assert_key_exists_and_type_is(self.user_configs, 'destinations', dict)
         for name, config in self.user_configs['destinations'].items():
-            if name == "__line__":
-                continue  # skip YAML line annotations
 
             node = Destination(name, config, earthmover=self)
             self.graph.add_node(f"$destinations.{name}", data=node)

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -8,7 +8,6 @@ import yaml
 import pandas as pd
 
 from typing import Optional
-from yaml import SafeLoader
 
 from earthmover.error_handler import ErrorHandler
 from earthmover.graph import Graph
@@ -16,6 +15,7 @@ from earthmover.runs_file import RunsFile
 from earthmover.nodes.destination import Destination
 from earthmover.nodes.source import Source
 from earthmover.nodes.transformation import Transformation
+from earthmover.yaml_parser import SafeLineEnvVarLoader
 from earthmover import util
 
 
@@ -377,24 +377,3 @@ class Earthmover:
             if not _expected_df.equals(_outputted_df):
                 self.logger.critical(f"Test output `{_outputted_file}` does not match expected output.")
                 exit(1)
-
-
-
-# This allows us to determine the YAML file line number for any element loaded from YAML
-# (very useful for debugging and giving meaningful error messages)
-# (derived from https://stackoverflow.com/a/53647080)
-# Also added env var interpolation based on
-# https://stackoverflow.com/questions/52412297/how-to-replace-environment-variable-value-in-yaml-file-to-be-parsed-using-python#answer-55301129
-class SafeLineEnvVarLoader(SafeLoader):
-
-    def construct_mapping(self, node, deep=False):
-        mapping = super().construct_mapping(node, deep=deep)
-
-        # expand env vars:
-        for k, v in mapping.items():
-            if isinstance(v, str):
-                mapping[k] = os.path.expandvars(v)
-
-        # Add 1 so line numbering starts at 1
-        mapping['__line__'] = node.start_mark.line + 1
-        return mapping

--- a/earthmover/node.py
+++ b/earthmover/node.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from typing import List
 
+from earthmover.yaml_parser import YamlMapping
 from earthmover import util
 
 from typing import TYPE_CHECKING
@@ -18,7 +19,7 @@ class Node:
     """
     CHUNKSIZE = 1024 * 1024 * 100  # 100 MB
 
-    def __init__(self, name: str, config: dict, *, earthmover: 'Earthmover'):
+    def __init__(self, name: str, config: YamlMapping, *, earthmover: 'Earthmover'):
         self.name = name
         self.config = config
         self.type = None
@@ -33,7 +34,7 @@ class Node:
         self.num_cols = None
 
         self.expectations = None
-        self.allowed_configs = {'__line__', 'debug', 'expect'}
+        self.allowed_configs = {'debug', 'expect'}
         self.debug = self.config.get('debug', False)
 
 
@@ -44,7 +45,7 @@ class Node:
         :return:
         """
         self.error_handler.ctx.update(
-            file=self.earthmover.config_file, line=self.config['__line__'], node=self, operation=None
+            file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
         )
 
         # Verify all configs provided by the user are specified for the node.
@@ -70,7 +71,7 @@ class Node:
         :return:
         """
         self.error_handler.ctx.update(
-            file=self.earthmover.config_file, line=self.config["__line__"], node=self, operation=None
+            file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
         )
         pass
 

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -40,9 +40,6 @@ class AddColumnsOperation(Operation):
 
         for col, val in self.columns_dict.items():
 
-            if col == "__line__":
-                continue
-
             # Apply the value as a static string if not obviously Jinja.
             if not util.contains_jinja(val):
                 self.data[col] = val
@@ -101,9 +98,6 @@ class ModifyColumnsOperation(Operation):
         super().execute()
 
         for col, val in self.columns_dict.items():
-
-            if col == "__line__":
-                continue
 
             # Apply the value as a static string if not obviously Jinja.
             if not util.contains_jinja(val):
@@ -168,8 +162,6 @@ class DuplicateColumnsOperation(Operation):
         _columns = set(self.data.columns)
 
         for old_col, new_col in self.columns_dict.items():
-            if old_col == "__line__":
-                continue
 
             if new_col in _columns:
                 self.logger.warning(
@@ -193,9 +185,6 @@ class DuplicateColumnsOperation(Operation):
         super().execute()
 
         for old_col, new_col in self.columns_dict.items():
-
-            if old_col=="__line__":
-                continue
 
             self.data[new_col] = self.data[old_col]
 
@@ -234,8 +223,6 @@ class RenameColumnsOperation(Operation):
         _columns = set(self.data.columns)
 
         for old_col, new_col in self.columns_dict.items():
-            if old_col == "__line__":
-                continue
 
             if new_col in _columns:
                 self.logger.warning(

--- a/earthmover/operations/groupby.py
+++ b/earthmover/operations/groupby.py
@@ -221,8 +221,6 @@ class GroupByOperation(Operation):
         result.columns = self.group_by_columns + [self.GROUP_SIZE_COL]
 
         for new_col_name, func in self.create_columns_dict.items():
-            if new_col_name == "__line__":
-                continue
 
             _pieces = re.findall(
                 "([A-Za-z0-9_]*)\(([A-Za-z0-9_]*)?,?(.*)?\)",

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -3,7 +3,6 @@ import os
 from yaml import SafeLoader
 
 
-
 class YamlMapping(dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -12,23 +11,49 @@ class YamlMapping(dict):
 
 class SafeLineEnvVarLoader(SafeLoader):
     """
-    This allows us to determine the YAML file line number for any element loaded from YAML
-    (very useful for debugging and giving meaningful error messages)
-    (derived from https://stackoverflow.com/a/53647080)
+    Convert the mapping to a YamlMapping in order to store line number internally
+        - Allows us to determine the line number for any element loaded from YAML file
+        - Very useful for debugging and giving meaningful error messages
+        - See https://stackoverflow.com/a/53647080 and https://stackoverflow.com/a/67254800
 
-    Also added env var interpolation based on
-    https://stackoverflow.com/questions/52412297
+    Add environment variable interpolation
+        - See https://stackoverflow.com/questions/52412297
     """
     def construct_mapping(self, node, deep=False):
+        """
+        Add environment variable interpolation to Constructor.construct_mapping()
+
+        :param node:
+        :param deep:
+        :return:
+        """
         mapping = super().construct_mapping(node, deep=deep)
 
-        # expand env vars:
+        #
         for k, v in mapping.items():
             if isinstance(v, str):
                 mapping[k] = os.path.expandvars(v)
 
-        # Convert the mapping to a YamlMapping in order to store line number internally.
-        # Add 1 so line numbering starts at 1
-        mapping = YamlMapping(mapping)
-        mapping.__line__ = node.start_mark.line + 1
         return mapping
+
+    def construct_yaml_map(self, node):
+        """
+        Add line numbers as attribute of pyyaml.Constructor
+        - See https://github.com/yaml/pyyaml
+
+        :param node:
+        :return:
+        """
+        data = YamlMapping()  # Originally `data = {}`
+        data.__line__ = node.start_mark.line + 1  # Start line numbering at 1
+        yield data
+
+        value = self.construct_mapping(node)
+        data.update(value)
+
+
+
+SafeLineEnvVarLoader.add_constructor(
+    'tag:yaml.org,2002:map',
+    SafeLineEnvVarLoader.construct_yaml_map
+)

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -1,12 +1,12 @@
 import os
 
+from dataclasses import dataclass
 from yaml import SafeLoader
 
 
+@dataclass
 class YamlMapping(dict):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__line__ = None
+    __line__: int = None
 
 
 class SafeLineEnvVarLoader(SafeLoader):

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -1,0 +1,23 @@
+import os
+
+from yaml import SafeLoader
+
+
+# This allows us to determine the YAML file line number for any element loaded from YAML
+# (very useful for debugging and giving meaningful error messages)
+# (derived from https://stackoverflow.com/a/53647080)
+# Also added env var interpolation based on
+# https://stackoverflow.com/questions/52412297/how-to-replace-environment-variable-value-in-yaml-file-to-be-parsed-using-python#answer-55301129
+class SafeLineEnvVarLoader(SafeLoader):
+
+    def construct_mapping(self, node, deep=False):
+        mapping = super().construct_mapping(node, deep=deep)
+
+        # expand env vars:
+        for k, v in mapping.items():
+            if isinstance(v, str):
+                mapping[k] = os.path.expandvars(v)
+
+        # Add 1 so line numbering starts at 1
+        mapping['__line__'] = node.start_mark.line + 1
+        return mapping

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -5,8 +5,8 @@ from yaml import SafeLoader
 
 
 class YamlMapping(dict):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.__line__ = None
 
 

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -3,13 +3,22 @@ import os
 from yaml import SafeLoader
 
 
-# This allows us to determine the YAML file line number for any element loaded from YAML
-# (very useful for debugging and giving meaningful error messages)
-# (derived from https://stackoverflow.com/a/53647080)
-# Also added env var interpolation based on
-# https://stackoverflow.com/questions/52412297/how-to-replace-environment-variable-value-in-yaml-file-to-be-parsed-using-python#answer-55301129
-class SafeLineEnvVarLoader(SafeLoader):
 
+class YamlMapping(dict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.__line__ = None
+
+
+class SafeLineEnvVarLoader(SafeLoader):
+    """
+    This allows us to determine the YAML file line number for any element loaded from YAML
+    (very useful for debugging and giving meaningful error messages)
+    (derived from https://stackoverflow.com/a/53647080)
+
+    Also added env var interpolation based on
+    https://stackoverflow.com/questions/52412297
+    """
     def construct_mapping(self, node, deep=False):
         mapping = super().construct_mapping(node, deep=deep)
 
@@ -18,6 +27,8 @@ class SafeLineEnvVarLoader(SafeLoader):
             if isinstance(v, str):
                 mapping[k] = os.path.expandvars(v)
 
+        # Convert the mapping to a YamlMapping in order to store line number internally.
         # Add 1 so line numbering starts at 1
-        mapping['__line__'] = node.start_mark.line + 1
+        mapping = YamlMapping(mapping)
+        mapping.__line__ = node.start_mark.line + 1
         return mapping


### PR DESCRIPTION
This updates `SafeLineEnvVarLoader` to construct `YamlMapping`s with a built-in `__line__` attribute, instead of building dicts with an extra "__line__" key. This change allows all `if key == '__line__'` checks to be removed from the project. The custom Loader and dict class are isolated in their own `yaml_mapping.py` file.