### PR TITLE
Refactor/assert keys

### DIFF
--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -114,8 +114,8 @@ class Earthmover:
 
         ### Build all nodes into a graph
         # sources:
-        self.error_handler.assert_key_exists_and_type_is(self.user_configs, 'sources', dict)
-        for name, config in self.user_configs['sources'].items():
+        _sources = self.error_handler.assert_get_key(self.user_configs, 'sources', dtype=dict)
+        for name, config in _sources.items():
             if name == "__line__":
                 continue  # skip YAML line annotations
 
@@ -123,29 +123,30 @@ class Earthmover:
             self.graph.add_node(f"$sources.{name}", data=node)
 
         # transformations:
-        if 'transformations' in self.user_configs:
-            self.error_handler.assert_key_type_is(self.user_configs, 'transformations', dict)
+        _transformations = self.error_handler.assert_get_key(
+            self.user_configs, 'transformations',
+            dtype=dict, required=False, default={}
+        )
+        for name, config in _transformations.items():
+            if name == "__line__":
+                continue  # skip YAML line annotations
 
-            for name, config in self.user_configs['transformations'].items():
-                if name == "__line__":
-                    continue  # skip YAML line annotations
+            node = Transformation(name, config, earthmover=self)
+            self.graph.add_node(f"$transformations.{name}", data=node)
 
-                node = Transformation(name, config, earthmover=self)
-                self.graph.add_node(f"$transformations.{name}", data=node)
+            for source in node.sources:
+                if not self.graph.ref(source):
+                    self.error_handler.throw(
+                        f"invalid source {source}"
+                    )
+                    raise
 
-                for source in node.sources:
-                    if not self.graph.ref(source):
-                        self.error_handler.throw(
-                            f"invalid source {source}"
-                        )
-                        raise
-
-                    if source != f"$transformations.{name}":
-                        self.graph.add_edge(source, f"$transformations.{name}")
+                if source != f"$transformations.{name}":
+                    self.graph.add_edge(source, f"$transformations.{name}")
 
         # destinations:
-        self.error_handler.assert_key_exists_and_type_is(self.user_configs, 'destinations', dict)
-        for name, config in self.user_configs['destinations'].items():
+        _destinations = self.error_handler.assert_get_key(self.user_configs, 'destinations', dtype=dict)
+        for name, config in _destinations.items():
             if name == "__line__":
                 continue  # skip YAML line annotations
 

--- a/earthmover/error_handler.py
+++ b/earthmover/error_handler.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 class ErrorContext:
     """
 
@@ -75,22 +77,34 @@ class ErrorHandler:
     def __init__(self, file=None, line=None, node=None, operation=None):
         self.ctx = ErrorContext(file=file, line=line, node=node, operation=operation)
 
-    def assert_key_exists(self, obj, key):
-        if key not in obj.keys():
+    def assert_get_key(self, obj: dict, key: str,
+        dtype: Optional[type] = None,
+        required: bool = False
+    ) -> Optional[object]:
+        """
+
+        :param obj:
+        :param key:
+        :param dtype:
+        :param required:
+        :return:
+        """
+        value = obj.get(key)
+
+        if value is None and required:
             raise Exception(
-                self.ctx + f"must define `{key}`"
+                f"{self.ctx} must define `{key}`"
             )
 
-    def assert_key_type_is(self, obj, key, desired_type):
-        if not isinstance(obj[key], desired_type):
-            _key_type = type(obj[key])
+        if value is not None and dtype and not isinstance(value, dtype):
             raise Exception(
-                self.ctx + f"`{key}` is defined, but wrong type (should be {desired_type}, is {_key_type})"
+                f"{self.ctx} `{key}` is defined, but wrong type (should be {dtype}, is {type(value)})"
             )
 
-    def assert_key_exists_and_type_is(self, obj, key, desired_type):
-        self.assert_key_exists(obj, key)
-        self.assert_key_type_is(obj, key, desired_type)
+        return value
 
-    def throw(self, message):
-        raise Exception(self.ctx + message)
+    def throw(self, message: str):
+        raise Exception(
+            f"{self.ctx} {message})"
+        )
+

--- a/earthmover/error_handler.py
+++ b/earthmover/error_handler.py
@@ -79,7 +79,8 @@ class ErrorHandler:
 
     def assert_get_key(self, obj: dict, key: str,
         dtype: Optional[type] = None,
-        required: bool = False
+        required: bool = True,
+        default: Optional[object] = None
     ) -> Optional[object]:
         """
 
@@ -87,16 +88,20 @@ class ErrorHandler:
         :param key:
         :param dtype:
         :param required:
+        :param default:
         :return:
         """
         value = obj.get(key)
 
-        if value is None and required:
-            raise Exception(
-                f"{self.ctx} must define `{key}`"
-            )
+        if value is None:
+            if required:
+                raise Exception(
+                    f"{self.ctx} must define `{key}`"
+                )
+            else:
+                return default
 
-        if value is not None and dtype and not isinstance(value, dtype):
+        if dtype and not isinstance(value, dtype):
             raise Exception(
                 f"{self.ctx} `{key}` is defined, but wrong type (should be {dtype}, is {type(value)})"
             )
@@ -107,4 +112,3 @@ class ErrorHandler:
         raise Exception(
             f"{self.ctx} {message})"
         )
-

--- a/earthmover/node.py
+++ b/earthmover/node.py
@@ -56,9 +56,7 @@ class Node:
                 )
 
         # Always check for expectations
-        if 'expect' in self.config:
-            self.error_handler.assert_key_type_is(self.config, 'expect', list)
-            self.expectations = self.config['expect']
+        self.expectations = self.error_handler.assert_get_key(self.config, 'expect', dtype=list, required=False)
 
         pass
 

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -22,8 +22,8 @@ class Destination(Node):
 
         self.mode = None  # Documents which class was chosen.
 
-        self.error_handler.assert_key_exists_and_type_is(self.config, "source", str)
-        self.source = self.config['source']
+        # Should this be moved to compile?
+        self.source = self.error_handler.assert_get_key(self.config, 'source', dtype=str)
 
 
     @abc.abstractmethod
@@ -76,9 +76,7 @@ class FileDestination(Destination):
         :return:
         """
         super().compile()
-
-        self.error_handler.assert_key_exists_and_type_is(self.config, "template", str)
-        self.template = self.config['template']
+        self.template = self.error_handler.assert_get_key(self.config, 'template', dtype=str)
 
         #config->extension is optional: if not present, we assume the destination name has an extension
         extension = ""

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -64,22 +64,16 @@ class Operation(Node):
         self.allowed_configs.update(['operation', 'sources', 'source'])
 
         # `source` and `source_list` are mutually-exclusive attributes.
-        self.source = None
-        self.source_list = None  # For operations with multiple sources (i.e., dataframe operations)
+        # `source_list` is for operations with multiple sources (i.e., dataframe operations)
+        self.source = self.error_handler.assert_get_key(self.config, 'source', dtype=str, required=False)
+        self.source_list = self.error_handler.assert_get_key(self.config, 'sources', dtype=list, required=False)
         self.source_data_list = None  # Retrieved data for operations with multiple sources
 
-        if 'sources' in self.config:
-            self.error_handler.assert_key_type_is(self.config, 'sources', list)
-            self.source_list = self.config['sources']
-
-        elif 'source' in self.config:
-            self.error_handler.assert_key_type_is(self.config, 'source', str)
-            self.source = self.config['source']
-
-        else:
+        if bool(self.source) == bool(self.source_list):  # Fail if both or neither are populated.
             self.error_handler.throw(
                 "A `source` or a list of `sources` must be defined for any operation!"
             )
+            raise
 
 
     @abc.abstractmethod

--- a/earthmover/nodes/transformation.py
+++ b/earthmover/nodes/transformation.py
@@ -19,8 +19,8 @@ class Transformation(Node):
         self.operations = []
         self.sources = set()
 
-        self.error_handler.assert_key_exists_and_type_is(self.config, 'operations', list)
-        for idx, operation_config in enumerate(self.config.get('operations'), start=1):
+        _operations = self.error_handler.assert_get_key(self.config, 'operations', dtype=list)
+        for idx, operation_config in enumerate(_operations, start=1):
 
             operation = Operation(operation_config, earthmover=self.earthmover)
             self.operations.append(operation)

--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -41,48 +41,24 @@ class JoinOperation(Operation):
         super().compile()
 
         # Check left keys
-        if 'left_key' not in self.config and 'left_keys' not in self.config:
+        _key  = self.error_handler.assert_get_key(self.config, 'left_key', dtype=str, required=False)
+        _keys = self.error_handler.assert_get_key(self.config, 'left_keys', dtype=list, required=False)
+
+        if bool(_key) == bool(_keys):  # Fail if both or neither are populated.
             self.error_handler.throw("must define `left_key` or `left_keys`")
             raise
 
-        _key = self.config.get('left_key')
-        _keys = self.config.get('left_keys')
-
-        if _key:
-            self.error_handler.assert_key_type_is(self.config, 'left_key', str)
-            self.left_keys = [_key]
-
-        elif _keys:
-            self.error_handler.assert_key_type_is(self.config, 'left_keys', list)
-            self.left_keys = _keys
-        else:
-            self.error_handler.throw(
-                "`left_key(s)` incorrectly specified (should be string or list of strings)"
-            )
-            raise
-
+        self.left_keys = _keys or [_key]  # `[None]` evaluates to True
 
         # Check right keys
-        if 'right_key' not in self.config and 'right_keys' not in self.config:
+        _key  = self.error_handler.assert_get_key(self.config, 'right_key', dtype=str, required=False)
+        _keys = self.error_handler.assert_get_key(self.config, 'right_keys', dtype=list, required=False)
+
+        if bool(_key) == bool(_keys):  # Fail if both or neither are populated.
             self.error_handler.throw("must define `right_key` or `right_keys`")
             raise
 
-        _key = self.config.get('right_key')
-        _keys = self.config.get('right_keys')
-
-        if _key:
-            self.error_handler.assert_key_type_is(self.config, 'right_key', str)
-            self.right_keys = [_key]
-
-        elif _keys:
-            self.error_handler.assert_key_type_is(self.config, 'right_keys', list)
-            self.right_keys = _keys
-        else:
-            self.error_handler.throw(
-                "`right_key(s)` incorrectly specified (should be string or list of strings)"
-            )
-            raise
-
+        self.right_keys = _keys or [_key]  # `[None]` evaluates to True
 
         # Check join type
         self.join_type = self.config.get('join_type')
@@ -96,7 +72,6 @@ class JoinOperation(Operation):
             )
             raise
 
-
         # Verify the correct number of datasets has been provided.
         if len(self.source_list) != 2:
             self.error_handler.throw(
@@ -104,29 +79,12 @@ class JoinOperation(Operation):
             )
             raise
 
-
-        # Check left columns
-        _keep_cols = self.config.get('left_keep_columns')
-        _drop_cols = self.config.get('left_drop_columns')
-
-        if _keep_cols:
-            self.error_handler.assert_key_type_is(self.config, 'left_keep_columns', list)
-            self.left_keep_cols = _keep_cols
-        elif _drop_cols:
-            self.error_handler.assert_key_type_is(self.config, 'left_drop_columns', list)
-            self.left_drop_cols = _drop_cols
-
-
-        # Check right columns
-        _keep_cols = self.config.get('right_keep_columns')
-        _drop_cols = self.config.get('right_drop_columns')
-
-        if _keep_cols:
-            self.error_handler.assert_key_type_is(self.config, 'right_keep_columns', list)
-            self.right_keep_cols = _keep_cols
-        elif _drop_cols:
-            self.error_handler.assert_key_type_is(self.config, 'right_drop_columns', list)
-            self.right_drop_cols = _drop_cols
+        # Collect columns
+        #   - There is a "if keep - elif drop" block in verify, so doesn't matter if both are populated.
+        self.left_keep_cols  = self.error_handler.assert_get_key(self.config, 'left_keep_columns', dtype=list, required=False)
+        self.left_drop_cols  = self.error_handler.assert_get_key(self.config, 'left_drop_columns', dtype=list, required=False)
+        self.right_keep_cols = self.error_handler.assert_get_key(self.config, 'right_keep_columns', dtype=list, required=False)
+        self.right_drop_cols = self.error_handler.assert_get_key(self.config, 'right_drop_columns', dtype=list, required=False)
 
 
     def verify(self):

--- a/earthmover/operations/groupby.py
+++ b/earthmover/operations/groupby.py
@@ -26,12 +26,8 @@ class GroupByWithCountOperation(Operation):
         :return:
         """
         super().compile()
-
-        self.error_handler.assert_key_exists_and_type_is(self.config, 'group_by_columns', list)
-        self.group_by_columns = self.config['group_by_columns']
-
-        self.error_handler.assert_key_exists_and_type_is(self.config, 'count_column', str)
-        self.count_column = self.config['count_column']
+        self.group_by_columns = self.error_handler.assert_get_key(self.config, 'group_by_columns', dtype=list)
+        self.count_column     = self.error_handler.assert_get_key(self.config, 'count_column', dtype=str)
 
 
     def verify(self):
@@ -100,18 +96,13 @@ class GroupByWithAggOperation(Operation):
         :return:
         """
         super().compile()
+        self.group_by_columns = self.error_handler.assert_get_key(self.config, 'group_by_columns', dtype=list)
+        self.agg_column       = self.error_handler.assert_get_key(self.config, 'agg_column', dtype=str)
 
-        self.error_handler.assert_key_exists_and_type_is(self.config, 'group_by_columns', list)
-        self.group_by_columns = self.config['group_by_columns']
-
-        self.error_handler.assert_key_exists_and_type_is(self.config, 'agg_column', str)
-        self.agg_column = self.config['agg_column']
-
-        if 'separator' in self.config:
-            self.error_handler.assert_key_exists_and_type_is(self.config, 'separator', str)
-            self.separator = self.config['separator']
-        else:
-            self.separator = self.DEFAULT_AGG_SEP
+        self.separator = self.error_handler.assert_get_key(
+            self.config, 'separator', dtype=str,
+            required=False, default=self.DEFAULT_AGG_SEP
+        )
 
     def verify(self):
         """
@@ -183,12 +174,8 @@ class GroupByOperation(Operation):
         :return:
         """
         super().compile()
-
-        self.error_handler.assert_key_exists_and_type_is(self.config, 'group_by_columns', list)
-        self.group_by_columns = self.config['group_by_columns']
-
-        self.error_handler.assert_key_exists_and_type_is(self.config, "create_columns", dict)
-        self.create_columns_dict = self.config['create_columns']
+        self.group_by_columns    = self.error_handler.assert_get_key(self.config, 'group_by_columns', dtype=list)
+        self.create_columns_dict = self.error_handler.assert_get_key(self.config, 'create_columns', dtype=dict)
 
 
     def verify(self):

--- a/earthmover/operations/row.py
+++ b/earthmover/operations/row.py
@@ -10,7 +10,7 @@ class DistinctRowsOperation(Operation):
 
         self.allowed_configs.update(['column', 'columns'])
 
-        self.columns_list = []
+        self.columns_list = None
 
 
     def compile(self):
@@ -20,17 +20,16 @@ class DistinctRowsOperation(Operation):
         """
         super().compile()
 
-        #
-        _column = self.config.get('column')
-        _columns = self.config.get('columns')
+        # Only 'column' or 'columns' can be populated
+        _column  = self.error_handler.assert_get_key(self.config, 'column', dtype=str, required=False)
+        _columns = self.error_handler.assert_get_key(self.config, 'columns', dtype=list, required=False)
 
         if _column:
-            self.error_handler.assert_key_type_is(self.config, 'column', str)
             self.columns_list = [_column]
-
         elif _columns:
-            self.error_handler.assert_key_type_is(self.config, 'columns', list)
             self.columns_list = _columns
+        else:
+            self.columns_list = []
 
 
     def verify(self):
@@ -84,12 +83,8 @@ class FilterRowsOperation(Operation):
         """
         super().compile()
 
-        self.error_handler.assert_key_exists_and_type_is(self.config, "query", str)
-        self.query = self.config['query']
-
-        #
-        self.error_handler.assert_key_exists_and_type_is(self.config, "behavior", str)
-        self.behavior = self.config['behavior']
+        self.query    = self.error_handler.assert_get_key(self.config, 'query', dtype=str)
+        self.behavior = self.error_handler.assert_get_key(self.config, 'behavior', dtype=str)
 
         if self.behavior not in self.BEHAVIORS:
             self.error_handler.throw(


### PR DESCRIPTION
This PR combines the logic of three ErrorHandler functions (assert_key_exists_and_type_is, assert_key_exists, assert_key_type_is) into a single method `assert_get_key` that cleans up most of the config key-retrieval code. This removes a lot of boilerplate and makes reviewing the logic of the code easier.

Note: I removed the original functions from the code, instead of deprecating them.