### PR TITLE
implementing ability to use Jinja inside config YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Note that templates may [include](https://jinja.palletsprojects.com/en/3.1.x/tem
 ## YAML configuration
 All the instructions for this tool &mdash; where to find the source data, what transformations to apply to it, and how and where to save the output &mdash; are specified in a single YAML configuration file. Example YAML configuration files and projects can be found in `example_projects/`.
 
-The YAML configuration may also contain [Jinja](https://jinja.palletsprojects.com/en/3.1.x/) and [environment variable references](#environment-variable-references).
+The YAML configuration may also [contain Jinja](#jinja-in-yaml-configuration) and [environment variable references](#environment-variable-references).
 
 The general structure of the YAML involves four main sections:
 1. [`config`](#config), which specifies options like the logging level and parameter defaults

--- a/README.md
+++ b/README.md
@@ -616,7 +616,14 @@ earthmover --version
 This tool includes several special features:
 
 ## Jinja in YAML configuration
-You may use Jinja in the YAML configuration, which will be parsed at load time. For example:
+You may use Jinja in the YAML configuration, which will be parsed at load time. Only the `config` section may not contain Jinja, except for `macros` which are made available both at parse-time for Jinja in the YAML configuration and at run-time for Jinja in `add_columns` or `modify_columns` transformation operations.
+
+The following example
+1. loads 9 source files
+1. adds a column indicating the source file each row came from
+1. unions the sources together
+1. if an environment variable or parameter `DO_FILTERING=True` is passed, filters out certain rows
+
 ```yaml
 config:
   show_graph: True
@@ -660,11 +667,7 @@ destinations:
     extension: jsonl
     linearize: True
 ```
-This example
-1. loads 9 source files
-1. adds a column indicating the source file each row came from
-1. unions the sources together
-1. if an environment variable or parameter `DO_FILTERING=True` is passed, filters out certain rows
+
 
 ## Selectors
 Run only portions of the [DAG](#dag) by using a selector:

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ The following example
 1. unions the sources together
 1. if an environment variable or parameter `DO_FILTERING=True` is passed, filters out certain rows
 
-```yaml
+```jinja
 config:
   show_graph: True
   parameter_defaults:

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -113,7 +113,7 @@ class Earthmover:
                     continue
 
                 # Find the end of the config block (i.e., the next top-level field)
-                if start is not None and not line.startswith(tuple(string.whitespace)+tuple("#")):
+                if start is not None and not line.startswith(tuple(string.whitespace+"#")):
                     end = idx
                     break
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -151,7 +151,7 @@ class Earthmover:
                 raise
             
             try:
-                self.config_yaml = self.config_template.render().replace(": >\n", ": ''")
+                self.config_yaml = self.config_template.render()
             except Exception as err:
                 lineno = util.jinja2_template_error_lineno()
                 if lineno: lineno = ", near line " + str(lineno - self.macros_lines - 1)

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -170,13 +170,12 @@ class Earthmover:
                     f"YAML could not be parsed: {linear_err}"
                 )
                 raise
-
-        self.error_handler.update_context(self.config_template, self.macros_lines)
         
-        with open("./earthmover_yaml.yml", "w") as f:
-            f.write(self.config_yaml)
-        with open("./earthmover_template.yml", "w") as f:
-            f.write(self.config_template_string)
+        # Uncomment the following to view original template yaml and parsed yaml:
+        # with open("./earthmover_yaml.yml", "w") as f:
+        #     f.write(self.config_yaml)
+        # with open("./earthmover_template.yml", "w") as f:
+        #     f.write(self.config_template_string)
 
         return configs_pass2
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -115,6 +115,7 @@ class Earthmover:
                 # Find the end of the config block (i.e., the next top-level field)
                 if start is not None and not line.startswith(tuple(string.whitespace)):
                     end = idx
+                    break
 
             # Read the configs block and extract the (optional) macros field.
             if start is not None and end is not None:

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -113,7 +113,7 @@ class Earthmover:
                     continue
 
                 # Find the end of the config block (i.e., the next top-level field)
-                if start is not None and not line.startswith(tuple(string.whitespace)):
+                if start is not None and not line.startswith(tuple(string.whitespace)+tuple("#")):
                     end = idx
                     break
 

--- a/earthmover/error_handler.py
+++ b/earthmover/error_handler.py
@@ -9,9 +9,16 @@ class ErrorContext:
         self.line = None
         self.node = None
         self.operation = None
+        self.config_template = ""
+        self.macros_lines = 0
 
         self.update(file=file, line=line, node=node, operation=operation)
+    
+    def update_config_template(self, config_template):
+        self.config_template = config_template
 
+    def update_macros_lines(self, macros_lines):
+        self.macros_lines = macros_lines
 
     def update(self, file=None, line=None, node=None, operation=None):
         self.file = file
@@ -42,7 +49,7 @@ class ErrorContext:
             if arg == 'operation':
                 self.operation = None
 
-
+    
     def __repr__(self) -> str:
         """
         Example error messages:
@@ -74,8 +81,16 @@ class ErrorContext:
 
 
 class ErrorHandler:
+    
+    config_template = None
+    macros_lines = 0
+
     def __init__(self, file=None, line=None, node=None, operation=None):
         self.ctx = ErrorContext(file=file, line=line, node=node, operation=operation)
+
+    def update_context(self, config_template, macros_lines):
+        self.ctx.update_config_template(config_template)
+        self.ctx.update_macros_lines(macros_lines)
 
     def assert_get_key(self, obj: dict, key: str,
         dtype: Optional[type] = None,

--- a/earthmover/error_handler.py
+++ b/earthmover/error_handler.py
@@ -9,10 +9,9 @@ class ErrorContext:
         self.line = None
         self.node = None
         self.operation = None
-        self.config_template = ""
-        self.macros_lines = 0
 
         self.update(file=file, line=line, node=node, operation=operation)
+
 
     def update(self, file=None, line=None, node=None, operation=None):
         self.file = file
@@ -75,10 +74,6 @@ class ErrorContext:
 
 
 class ErrorHandler:
-    
-    config_template = None
-    macros_lines = 0
-
     def __init__(self, file=None, line=None, node=None, operation=None):
         self.ctx = ErrorContext(file=file, line=line, node=node, operation=operation)
 

--- a/earthmover/error_handler.py
+++ b/earthmover/error_handler.py
@@ -13,12 +13,6 @@ class ErrorContext:
         self.macros_lines = 0
 
         self.update(file=file, line=line, node=node, operation=operation)
-    
-    def update_config_template(self, config_template):
-        self.config_template = config_template
-
-    def update_macros_lines(self, macros_lines):
-        self.macros_lines = macros_lines
 
     def update(self, file=None, line=None, node=None, operation=None):
         self.file = file
@@ -49,7 +43,7 @@ class ErrorContext:
             if arg == 'operation':
                 self.operation = None
 
-    
+
     def __repr__(self) -> str:
         """
         Example error messages:
@@ -87,10 +81,6 @@ class ErrorHandler:
 
     def __init__(self, file=None, line=None, node=None, operation=None):
         self.ctx = ErrorContext(file=file, line=line, node=node, operation=operation)
-
-    def update_context(self, config_template, macros_lines):
-        self.ctx.update_config_template(config_template)
-        self.ctx.update_macros_lines(macros_lines)
 
     def assert_get_key(self, obj: dict, key: str,
         dtype: Optional[type] = None,

--- a/earthmover/node.py
+++ b/earthmover/node.py
@@ -120,6 +120,7 @@ class Node:
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=expectation_result_col),
                     template=template,
+                    template_str="{{" + expectation + "}}",
                     error_handler = self.error_handler
                 )
 

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -56,7 +56,7 @@ class Operation(Node):
 
 
     def __init__(self, name: str, config: dict, *, earthmover: 'Earthmover'):
-        full_name = f"{name}.operations:{self.config.get('operation')}"
+        full_name = f"{name}.operations:{config.get('operation')}"
         super().__init__(full_name, config, earthmover=earthmover)
 
         self.type = "transformation" # self.config.get('operation')

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -11,7 +11,7 @@ class Operation(Node):
     """
 
     """
-    def __new__(cls, config: dict, *, earthmover: 'Earthmover'):
+    def __new__(cls, node_name: str, config: dict, *, earthmover: 'Earthmover'):
         """
         :param config:
         :param earthmover:
@@ -55,11 +55,12 @@ class Operation(Node):
         return object.__new__(operation_class)
 
 
-    def __init__(self, config: dict, *, earthmover: 'Earthmover'):
+    def __init__(self, node_name: str, config: dict, *, earthmover: 'Earthmover'):
         _name = config.get('operation')
-        super().__init__(_name, config, earthmover=earthmover)
+        super().__init__(node_name + ".operations:" + _name, config, earthmover=earthmover)
 
-        self.type = self.config.get('operation')
+        self.type = "transformation" # self.config.get('operation')
+        self.name = node_name + ".operations:" + self.config.get('operation')
 
         self.allowed_configs.update(['operation', 'sources', 'source'])
 

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -11,7 +11,7 @@ class Operation(Node):
     """
 
     """
-    def __new__(cls, node_name: str, config: dict, *, earthmover: 'Earthmover'):
+    def __new__(cls, name: str, config: dict, *, earthmover: 'Earthmover'):
         """
         :param config:
         :param earthmover:
@@ -55,12 +55,11 @@ class Operation(Node):
         return object.__new__(operation_class)
 
 
-    def __init__(self, node_name: str, config: dict, *, earthmover: 'Earthmover'):
-        _name = config.get('operation')
-        super().__init__(node_name + ".operations:" + _name, config, earthmover=earthmover)
+    def __init__(self, name: str, config: dict, *, earthmover: 'Earthmover'):
+        full_name = f"{name}.operations:{self.config.get('operation')}"
+        super().__init__(full_name, config, earthmover=earthmover)
 
         self.type = "transformation" # self.config.get('operation')
-        self.name = node_name + ".operations:" + self.config.get('operation')
 
         self.allowed_configs.update(['operation', 'sources', 'source'])
 

--- a/earthmover/nodes/transformation.py
+++ b/earthmover/nodes/transformation.py
@@ -22,7 +22,7 @@ class Transformation(Node):
         _operations = self.error_handler.assert_get_key(self.config, 'operations', dtype=list)
         for idx, operation_config in enumerate(_operations, start=1):
 
-            operation = Operation(operation_config, earthmover=self.earthmover)
+            operation = Operation(self.name, operation_config, earthmover=self.earthmover)
             self.operations.append(operation)
 
             # Sources are defined in a 'source_list' or 'source' class attribute, but never both.

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -51,7 +51,7 @@ class AddColumnsOperation(Operation):
                 except Exception as err:
                     self.error_handler.ctx.remove('line')
                     self.error_handler.throw(
-                        f"syntax error in Jinja template for column `{col}` of `add_columns` operation ({err}):\n===> " + val
+                        f"syntax error in Jinja template for column `{col}` of `add_columns` operation ({err}):\n===> {val}"
                     )
                     raise
 
@@ -110,7 +110,7 @@ class ModifyColumnsOperation(Operation):
                 except Exception as err:
                     self.error_handler.ctx.remove('line')
                     self.error_handler.throw(
-                        f"syntax error in Jinja template for column `{col}` of `modify_columns` operation ({err}):\n===> " + val
+                        f"syntax error in Jinja template for column `{col}` of `modify_columns` operation ({err}):\n===> {val}"
                     )
                     raise
 

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -49,8 +49,9 @@ class AddColumnsOperation(Operation):
                     ).from_string(self.earthmover.state_configs['macros'] + val)
 
                 except Exception as err:
+                    self.error_handler.ctx.remove('line')
                     self.error_handler.throw(
-                        f"syntax error in Jinja template for column `{col}` of `add_columns` operation ({err})"
+                        f"syntax error in Jinja template for column `{col}` of `add_columns` operation ({err}):\n===> " + val
                     )
                     raise
 
@@ -58,6 +59,7 @@ class AddColumnsOperation(Operation):
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=col),
                     template=template,
+                    template_str=val,
                     error_handler=self.error_handler
                 )
 
@@ -106,8 +108,9 @@ class ModifyColumnsOperation(Operation):
                     ).from_string(self.earthmover.state_configs['macros'] + val)
 
                 except Exception as err:
+                    self.error_handler.ctx.remove('line')
                     self.error_handler.throw(
-                        f"syntax error in Jinja template for column `{col}` of `add_columns` operation ({err})"
+                        f"syntax error in Jinja template for column `{col}` of `modify_columns` operation ({err}):\n===> " + val
                     )
                     raise
 
@@ -118,6 +121,7 @@ class ModifyColumnsOperation(Operation):
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=col),
                     template=template,
+                    template_str=val,
                     error_handler=self.error_handler
                 )
 

--- a/earthmover/tests/earthmover.yaml
+++ b/earthmover/tests/earthmover.yaml
@@ -3,6 +3,8 @@ config:
   log_level: INFO
   show_stacktrace: False
   show_graph: False
+  parameter_defaults:
+    BASE_DIR: "."
 
 
 sources:
@@ -36,7 +38,7 @@ transformations:
       - operation: modify_columns
         source: $transformations.mammal_species
         columns:
-          id: 1_{{value}}
+          id: {%raw%}1_{{value}}{%endraw%}
   bird_species:
     operations:
       - operation: add_columns
@@ -46,7 +48,7 @@ transformations:
       - operation: modify_columns
         source: $transformations.bird_species
         columns:
-          id: 2_{{value}}
+          id: {%raw%}2_{{value}}{%endraw%}
   fish_species:
     operations:
       - operation: distinct_rows
@@ -59,7 +61,7 @@ transformations:
       - operation: modify_columns
         source: $transformations.fish_species
         columns:
-          id: 3_{{value}}
+          id: {%raw%}3_{{value}}{%endraw%}
   reptile_species:
     operations:
       - operation: add_columns
@@ -69,7 +71,7 @@ transformations:
       - operation: modify_columns
         source: $transformations.reptile_species
         columns:
-          id: 4_{{value}}
+          id: {%raw%}4_{{value}}{%endraw%}
   animal_species:
     operations:
       - operation: union
@@ -148,7 +150,7 @@ transformations:
       - operation: modify_columns
         source: $transformations.species_count_by_zoo
         columns:
-          count: "{% if value!=value %}0.0{% else %}{{value}}{% endif %}"
+          count: "{%raw%}{% if value!=value %}0.0{% else %}{{value}}{% endif %}{%endraw%}"
       - operation: add_columns
         source: $transformations.species_count_by_zoo
         columns:
@@ -187,7 +189,7 @@ transformations:
       - operation: modify_columns
         source: $transformations.zoo_count_by_year_founded
         columns:
-          date_founded: "{{value[0:4]}}"
+          date_founded: "{%raw%}{{value[0:4]}}{%endraw%}"
       - operation: rename_columns
         source: $transformations.zoo_count_by_year_founded
         columns:

--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -93,21 +93,22 @@ def render_jinja_template(row, template: jinja2.Template, template_str: str, *, 
 
 def jinja2_template_error_lineno():
     """
-    TODO: Populate this docstring and empty comments with further clarity.
-    :return:
+    function based on https://stackoverflow.com/questions/26967433/how-to-get-line-number-causing-an-exception-other-than-templatesyntaxerror-in
+    :return: int lineno
     """
     type, value, tb = exc_info()
 
-    #
+    # skip non-Jinja errors
     if not issubclass(type, jinja2.TemplateError):
         return None
 
-    #
+    # one particular Exception type has a lineno built in - grab it!
     if hasattr(value, 'lineno'):
         # in case of TemplateSyntaxError
         return value.lineno
 
-    #
+    # "tb" is "trace-back"; this walks through the traceback line-by-line looking
+    # for the relevant line, then extracts the line number
     while tb:
         if tb.tb_frame.f_code.co_filename == '<template>':
             return tb.tb_lineno

--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -92,12 +92,22 @@ def render_jinja_template(row, template: jinja2.Template, template_str: str, *, 
 
 
 def jinja2_template_error_lineno():
+    """
+    TODO: Populate this docstring and empty comments with further clarity.
+    :return:
+    """
     type, value, tb = exc_info()
+
+    #
     if not issubclass(type, jinja2.TemplateError):
         return None
+
+    #
     if hasattr(value, 'lineno'):
         # in case of TemplateSyntaxError
         return value.lineno
+
+    #
     while tb:
         if tb.tb_frame.f_code.co_filename == '<template>':
             return tb.tb_lineno

--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -69,6 +69,7 @@ def render_jinja_template(row, template: jinja2.Template, template_str: str, *, 
 
     :param row:
     :param template:
+    :param template_str:
     :param error_handler:
     :return:
     """
@@ -77,10 +78,15 @@ def render_jinja_template(row, template: jinja2.Template, template_str: str, *, 
 
     except Exception as err:
         error_handler.ctx.remove('line')
-        variables = "`, `".join(x for x in dict(row).keys())
-        if len(dict(row).keys()) > 0: variables = "\n(available variables are `" + variables + "`"
+
+        if dict(row):
+            _joined_keys = "`, `".join(dict(row).keys())
+            variables = f"\n(available variables are `{_joined_keys}`)"
+        else:
+            variables = f"\n(no available variables)"
+
         error_handler.throw(
-            f"Error rendering Jinja template: ({err}):\n===> {template_str}{variables}" 
+            f"Error rendering Jinja template: ({err}):\n===> {template_str}{variables}"
         )
         raise
 

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -1,4 +1,5 @@
 import os
+import jinja2
 
 from dataclasses import dataclass
 from yaml import SafeLoader
@@ -19,6 +20,7 @@ class SafeLineEnvVarLoader(SafeLoader):
     Add environment variable interpolation
         - See https://stackoverflow.com/questions/52412297
     """
+
     def construct_mapping(self, node, deep=False):
         """
         Add environment variable interpolation to Constructor.construct_mapping()
@@ -28,15 +30,9 @@ class SafeLineEnvVarLoader(SafeLoader):
         :return:
         """
         mapping = super().construct_mapping(node, deep=deep)
-
-        #
-        for k, v in mapping.copy().items():
-            del mapping[k]
-            if isinstance(v, str):
-                mapping[os.path.expandvars(k)] = os.path.expandvars(v)
-            else: mapping[os.path.expandvars(k)] = v
-
+        
         return mapping
+    
 
     def construct_yaml_map(self, node):
         """

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -1,5 +1,4 @@
 import os
-import jinja2
 
 from dataclasses import dataclass
 from yaml import SafeLoader
@@ -20,7 +19,6 @@ class SafeLineEnvVarLoader(SafeLoader):
     Add environment variable interpolation
         - See https://stackoverflow.com/questions/52412297
     """
-
     def construct_mapping(self, node, deep=False):
         """
         Add environment variable interpolation to Constructor.construct_mapping()
@@ -32,7 +30,6 @@ class SafeLineEnvVarLoader(SafeLoader):
         mapping = super().construct_mapping(node, deep=deep)
         
         return mapping
-    
 
     def construct_yaml_map(self, node):
         """

--- a/example_projects/01_simple/big_earthmover.yaml
+++ b/example_projects/01_simple/big_earthmover.yaml
@@ -1,6 +1,5 @@
 config:
   output_dir: ./output/
-  # memory_limit: 2GB
   # show_stacktrace: True
   # show_graph: True
   # log_level: DEBUG

--- a/example_projects/01_simple/earthmover.yaml
+++ b/example_projects/01_simple/earthmover.yaml
@@ -13,7 +13,7 @@ sources:
     file: 
     header_rows: 1
     optional: True # this prevents an error due to `file` being blank... testing_destination just won't be created
-    columns: # this is optional UNLESS header_rows=0 OR required=False
+    columns: # this is optional UNLESS header_rows=0 OR optional=True
       - day
       - section
       - student_id

--- a/example_projects/02_join/earthmover.yaml
+++ b/example_projects/02_join/earthmover.yaml
@@ -1,6 +1,5 @@
 config:
   output_dir: ./output/
-  memory_limit: 4GB
   # log_level: DEBUG
   # show_stacktrace: True
   # show_graph: True

--- a/example_projects/06_subtemplates/earthmover.yaml
+++ b/example_projects/06_subtemplates/earthmover.yaml
@@ -1,7 +1,6 @@
 config:
   # log_level: DEBUG
   output_dir: ./output/
-  # memory_limit: 2GB
   # show_stacktrace: True
   # show_graph: True
 

--- a/example_projects/07_filetypes/earthmover.yaml
+++ b/example_projects/07_filetypes/earthmover.yaml
@@ -1,7 +1,6 @@
 config:
   # log_level: DEBUG
   output_dir: ./output/
-  # memory_limit: 2GB
   # show_stacktrace: True
   # show_graph: True
 

--- a/example_projects/08_html/earthmover.yaml
+++ b/example_projects/08_html/earthmover.yaml
@@ -1,7 +1,6 @@
 config:
   # log_level: DEBUG
   output_dir: ./output/
-  # memory_limit: 2GB
   # show_stacktrace: True
   # show_graph: True
 

--- a/example_projects/10_jinja/earthmover.yaml
+++ b/example_projects/10_jinja/earthmover.yaml
@@ -1,0 +1,66 @@
+config:
+  output_dir: ./outputs/
+  log_level: DEBUG
+  show_graph: True
+  # show_stacktrace: True
+  macros: >
+    {% macro test() %}
+      testing!
+    {% endmacro %}
+  parameter_defaults:
+    DO_LINEARIZE: "True"
+
+sources:
+  incidents:
+    file: ./inputs/incidents.csv
+    header_rows: 1
+  actions:
+    file: ./inputs/actions.csv
+    header_rows: 1
+
+transformations:
+  {% for i in range(0,5) %}
+  actions{{i}}:
+    operations:
+      - operation: map_values
+        source: $sources.actions
+        column: discipline
+        map_file: ./xwalks/disciplines.csv
+  {% endfor%}
+  incidents:
+    operations:
+      - operation: map_values
+        source: $sources.incidents
+        column: location
+        map_file: ./xwalks/locations.csv
+      - operation: map_values
+        source: $transformations.incidents
+        column: behavior
+        map_file: ./xwalks/behaviors.csv
+      - operation: map_values
+        source: $transformations.incidents
+        column: weapon
+        map_file: ./xwalks/weapons.csv
+      - operation: add_columns
+        source: $sources.actions
+        columns:
+          new_column2: "{%raw%}{% for i in range(0,doesnt_exist) %}{{incident_id[0:2]}}{%endfor%}{%endraw%}"
+
+destinations:
+  disciplineIncidents:
+    source: $transformations.incidents
+    template: ./templates/disciplineIncident.jsont
+    extension: jsonl
+    linearize: ${DO_LINEARIZE}
+  studentDisciplineIncidentAssociations:
+    source: $transformations.incidents
+    template: ./templates/studentDisciplineIncidentAssociation.jsont
+    extension: jsonl
+    linearize: True
+  {% for i in range(0,5) %}
+  disciplineActions/{{i}}:
+    source: $transformations.actions{{i}}
+    template: ./templates/disciplineAction.jsont
+    extension: jsonl
+    linearize: True
+  {% endfor%}

--- a/example_projects/10_jinja/earthmover.yaml
+++ b/example_projects/10_jinja/earthmover.yaml
@@ -44,7 +44,7 @@ transformations:
       - operation: add_columns
         source: $sources.actions
         columns:
-          new_column2: "{%raw%}{% for i in range(0,doesnt_exist) %}{{incident_id[0:2]}}{%endfor%}{%endraw%}"
+          new_column2: "{%raw%}{{incident_id[0:2]}}{%endraw%}"
 
 destinations:
   disciplineIncidents:

--- a/example_projects/10_jinja/inputs/actions.csv
+++ b/example_projects/10_jinja/inputs/actions.csv
@@ -1,0 +1,7 @@
+action_id,incident_id,school_id,staff_id,student_id,date,length,discipline
+2100,1500,325,4463,92847,2022-04-14,5,In School Suspension
+2101,1501,327,4512,97612,2022-04-14,1,Parent Meeting
+2102,1502,324,4514,92614,2022-04-13,1,Removal from Classroom
+2103,1503,324,4514,95721,2022-04-13,1,Removal from Classroom
+2104,1504,325,4315,92741,2022-04-13,1,Apology Letter
+2015,1505,326,4417,93741,2022-04-13,1,Reflection

--- a/example_projects/10_jinja/inputs/incidents.csv
+++ b/example_projects/10_jinja/inputs/incidents.csv
@@ -1,0 +1,7 @@
+incident_id,school_id,staff_id,student_id,date,time,location,behavior,weapon
+1500,325,4463,92847,2022-04-13,12:34:00,Cafeteria,Assault,Knife
+1501,327,4512,97612,2022-04-13,12:56:00,Hallway,Code of Conduct Violation,
+1502,324,4514,92614,2022-04-13,13:51:00,Classroom,Drug Violation,
+1503,324,4514,95721,2022-04-13,13:51:00,Classroom,Drug Violation,
+1504,325,4315,92741,2022-04-13,14:41:00,Classroom,Harassment,
+1505,326,4417,93741,2022-04-13,15:13:00,Hallway,Tobacco Violation,

--- a/example_projects/10_jinja/templates/behaviorDescriptor.jsont
+++ b/example_projects/10_jinja/templates/behaviorDescriptor.jsont
@@ -1,0 +1,8 @@
+{% if not counter %}{% set counter = 0 %}{% endif %}{% set counter = counter + 1 %}
+{
+    "behaviorDescriptorId": {{counter}},
+    "codeValue": "{{behavior}}",
+    "description": "{{behavior}}",
+    "namespace": "uri://someschooldistrict.org/BehaviorDescriptor",
+    "shortDescription": "{{behavior}}",
+}

--- a/example_projects/10_jinja/templates/disciplineAction.jsont
+++ b/example_projects/10_jinja/templates/disciplineAction.jsont
@@ -1,0 +1,27 @@
+{
+    "responsibilitySchoolReference": {
+      "schoolId": {{school_id}}
+    },
+    "studentReference": {
+      "studentUniqueId": "{{student_id}} | {{new_column}}"
+    },
+    "disciplineActionIdentifier": "{{action_id}}",
+    "disciplineDate": "{{date}}",
+    "actualDisciplineActionLength": {{length}},
+    "disciplineActionLength": {{length}},
+    "disciplineActionLengthDifferenceReasonDescriptor": "uri://ed-fi.org/DisciplineActionLengthDifferenceReasonDescriptor#No Difference",
+    "disciplines": [
+      {
+        "disciplineDescriptor": "{{discipline}}"
+      }
+    ],
+    "staffs": [],
+    "studentDisciplineIncidentAssociations": [
+      {
+        "studentDisciplineIncidentAssociationReference": {
+          "incidentIdentifier": "{{incident_id}}",
+          "schoolId": {{school_id}}
+        }
+      }
+    ]
+}

--- a/example_projects/10_jinja/templates/disciplineDescriptor.jsont
+++ b/example_projects/10_jinja/templates/disciplineDescriptor.jsont
@@ -1,0 +1,8 @@
+{% if not counter %}{% set counter = 0 %}{% endif %}{% set counter = counter + 1 %}
+{
+    "disciplineDescriptorId": {{counter}},
+    "codeValue": "{{discipline}}",
+    "description": "{{discipline}}",
+    "namespace": "uri://someschooldistrict.org/DisciplineDescriptor",
+    "shortDescription": "{{discipline}}"
+  }

--- a/example_projects/10_jinja/templates/disciplineIncident.jsont
+++ b/example_projects/10_jinja/templates/disciplineIncident.jsont
@@ -1,0 +1,25 @@
+{
+    "schoolReference": {
+      "schoolId": {{school_id}}
+    },
+    "staffReference": {
+      "staffUniqueId": "{{staff_id}} | {{new_column2}}"
+    },
+    "incidentIdentifier": "{{incident_id}}",
+    "incidentDate": "{{date}}",
+    "incidentLocationDescriptor": "{{location}}",
+    "incidentTime": "{{time}}",
+    "reportedToLawEnforcement": false,
+    "behaviors": [
+      {
+        "behaviorDescriptor": "{{behavior}}"
+      }
+    ],
+    "weapons": [
+      {% if weapon %}
+      {
+        "weaponDescriptor": "{{weapon}}"
+      }
+      {% endif %}
+    ]
+}

--- a/example_projects/10_jinja/templates/locationDescriptor.jsont
+++ b/example_projects/10_jinja/templates/locationDescriptor.jsont
@@ -1,0 +1,8 @@
+{% if not counter %}{% set counter = 0 %}{% endif %}{% set counter = counter + 1 %}
+{
+    "behaviorDescriptorId": {{counter}},
+    "codeValue": "{{behavior}}",
+    "description": "{{behavior}}",
+    "namespace": "uri://someschooldistrict.org/BehaviorDescriptor",
+    "shortDescription": "{{behavior}}",
+}

--- a/example_projects/10_jinja/templates/studentDisciplineIncidentAssociation.jsont
+++ b/example_projects/10_jinja/templates/studentDisciplineIncidentAssociation.jsont
@@ -1,0 +1,11 @@
+{
+    "disciplineIncidentReference": {
+      "incidentIdentifier": "{{incident_id}}",
+      "schoolId": {{school_id}}
+    },
+    "studentReference": {
+      "studentUniqueId": "{{student_id}}"
+    },
+    "studentParticipationCodeDescriptor": "uri://ed-fi.org/StudentParticipationCodeDescriptor#Perpetrator",
+    "behaviors": []
+}

--- a/example_projects/10_jinja/templates/weaponDescriptor.jsont
+++ b/example_projects/10_jinja/templates/weaponDescriptor.jsont
@@ -1,0 +1,7 @@
+{
+    "weaponDescriptorId": {{id}},
+    "codeValue": "{{weapon}}",
+    "description": "{{weapon}}",
+    "namespace": "uri://someschooldistrict.org/WeaponDescriptor",
+    "shortDescription": "{{weapon}}",
+}

--- a/example_projects/10_jinja/xwalks/behaviors.csv
+++ b/example_projects/10_jinja/xwalks/behaviors.csv
@@ -1,0 +1,6 @@
+behavior,descriptor
+Assault,uri://someschooldistrict.org/BehaviorDescriptor#Assault
+Code of Conduct Violation,uri://someschooldistrict.org/BehaviorDescriptor#Code of Conduct Violation
+Drug Violation,uri://someschooldistrict.org/BehaviorDescriptor#Drug Violation
+Harassment,uri://someschooldistrict.org/BehaviorDescriptor#Harassment
+Tobacco Violation,uri://someschooldistrict.org/BehaviorDescriptor#Tobacco Violation

--- a/example_projects/10_jinja/xwalks/disciplines.csv
+++ b/example_projects/10_jinja/xwalks/disciplines.csv
@@ -1,0 +1,6 @@
+discipline,descriptor
+In School Suspension,uri://someschooldistrict.org/DisciplineDescriptor#In School Suspension
+Apology Letter,uri://someschooldistrict.org/DisciplineDescriptor#Apology Letter
+Reflection,uri://someschooldistrict.org/DisciplineDescriptor#Reflection
+Parent Meeting,uri://someschooldistrict.org/DisciplineDescriptor#Parent Meeting
+Removal from Classroom,uri://someschooldistrict.org/DisciplineDescriptor#Removal from Classroom

--- a/example_projects/10_jinja/xwalks/locations.csv
+++ b/example_projects/10_jinja/xwalks/locations.csv
@@ -1,0 +1,4 @@
+location,descriptor
+Cafeteria,uri://someschooldistrict.org/IncidentLocationDescriptor#Cafeteria
+Classroom,uri://someschooldistrict.org/IncidentLocationDescriptor#Classroom
+Hallway,uri://someschooldistrict.org/IncidentLocationDescriptor#Hallway

--- a/example_projects/10_jinja/xwalks/weapons.csv
+++ b/example_projects/10_jinja/xwalks/weapons.csv
@@ -1,0 +1,3 @@
+weapon,descriptor
+Knife,uri://someschooldistrict.org/WeaponDescriptor#Knife
+Gun,uri://someschooldistrict.org/WeaponDescriptor#Gun


### PR DESCRIPTION
This PR introduces a fairly large change to earthmover, allowing Jinja in the yaml configuration. This means the yaml may now contain two types of Jinja: (1) run-time Jinja, such as
```yaml
transformations:
  source1:
    operations:
      - operation: add_columns
        source: $sources.source1
        columns:
          area_code: "{%raw%}{{phone_number[0:3]}}{%endraw%}"
```
and (**NEW**) parse-time jinja such as
```yaml
sources:
{% for i in range(1,10) %}
  source{{i}}:
    file: ./inputs/source{{i}}.csv
    header_rows: 1
{% endfor%}

destinations:
{% for i in range(1,10) %}
  destination{{i}}:
    source: $sources.source{{i}}
    template: ./templates/destination.jsont
    extension: jsonl
    linearize: true
{% endfor%}
```
Previously, only run-time Jinja (1) was available in earthmover. The addition of parse-time Jinja (2) is a **breaking change** which requires run-time Jinja to be wrapped in `{%raw%}...{%endraw%}` tags as in the example above.

Additionally, this PR includes the following further features:
* two-step parsing of yaml, which means any `config.macros` are available at both parse-time and run-time
* optionally include a dict of `config.parameter_defaults` in the yaml, in case the user fails to specify some parameters/environment variables
* improved error reporting for run-time Jinja errors, giving the Jinja template that failed (but no yaml line numbers; mapping backward from parsed yaml line number to pre-parse yaml template line number is difficult with Jinja)
* improved error reporting for transformation operations, including the name of the transformation node in which the error occurred