### PR TITLE
several bugfixes

### DIFF
--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -101,7 +101,7 @@ def main(argv=None):
     if args.version:
         em_dir = os.path.dirname(os.path.abspath(__file__))
         version_file = os.path.join(em_dir, 'VERSION.txt')
-        with open(version_file, 'r') as f:
+        with open(version_file, 'r', encoding='utf-8') as f:
             VERSION = f.read().strip()
             print(f"earthmover, version {VERSION}")
         exit(0)
@@ -154,7 +154,7 @@ def main(argv=None):
             cli_state_configs=cli_state_configs
         )
     except Exception as err:
-        logger.exception(err, exc_info=False)
+        logger.exception(err, exc_info=True)
         raise  # Avoids linting error
 
     if args.command == 'compile':

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -90,7 +90,7 @@ class FileDestination(Destination):
 
         #
         try:
-            with open(self.template, 'r') as fp:
+            with open(self.template, 'r', encoding='utf-8') as fp:
                 template_string = fp.read()
 
         except Exception as err:
@@ -134,7 +134,7 @@ class FileDestination(Destination):
         self.data = self.data.fillna('')
 
         os.makedirs(os.path.dirname(self.file), exist_ok=True)
-        with open(self.file, 'w') as fp:
+        with open(self.file, 'w', encoding='utf-8') as fp:
 
             if self.header:
                 fp.write(self.header + "\n")

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -492,7 +492,7 @@ class MapValuesOperation(Operation):
 
 
         try:
-            with open(file, 'r') as fp:
+            with open(file, 'r', encoding='utf-8') as fp:
                 _translations_list = list(csv.reader(fp, delimiter=sep))
                 return dict(_translations_list[1:])
         

--- a/earthmover/runs_file.py
+++ b/earthmover/runs_file.py
@@ -58,7 +58,7 @@ class RunsFile:
         if selector:
             row_dict['selector'] = selector
 
-        with open(self.file, 'a') as fp:
+        with open(self.file, 'a', encoding='utf-8') as fp:
             writer = csv.DictWriter(fp, fieldnames=self.HEADER)
             writer.writerow(row_dict)
 
@@ -205,7 +205,7 @@ class RunsFile:
 
         :return:
         """
-        with open(self.file, 'x') as fp:
+        with open(self.file, 'x', encoding='utf-8') as fp:
             writer = csv.writer(fp)
             writer.writerow(self.HEADER)
 
@@ -215,7 +215,7 @@ class RunsFile:
 
         :return:
         """
-        with open(self.file, 'r') as fp:
+        with open(self.file, 'r', encoding='utf-8') as fp:
             runs = list(csv.DictReader(fp, delimiter=','))
 
         # Raise a warning for the user to manually reset or select a new log-runs file.

--- a/example_projects/10_jinja/earthmover.yaml
+++ b/example_projects/10_jinja/earthmover.yaml
@@ -4,9 +4,9 @@ config:
   # show_graph: True
   # show_stacktrace: True
   macros: >
-    {% macro test() %}
+    {% macro test() -%}
       testing!
-    {% endmacro %}
+    {%- endmacro %}
   parameter_defaults:
     DO_LINEARIZE: "True"
 
@@ -20,6 +20,7 @@ sources:
 
 transformations:
   {% for i in range(0,5) %}
+  # {{ test() }}
   actions{{i}}:
     operations:
       - operation: map_values

--- a/example_projects/run_all.sh
+++ b/example_projects/run_all.sh
@@ -56,8 +56,8 @@ earthmover
 rm -f output/*
 echo "  ... done!"
 
-echo "  running 10_simple..."
-cd ../10_simple/
+echo "  running 10_jinja..."
+cd ../10_jinja/
 earthmover
 rm -rf outputs/*
 echo "  ... done!"


### PR DESCRIPTION
 This PR fixes several bugs that have come up:

* `config.state_file` was being ignored when specified (thanks Mike and Eshara for pointing this out!)

* more issues with multi-line `config.macros` - the resolution here (hopefully the last one!) is to pre-load macros (so they can be injected into run-time Jinja contexts) and then just allow the Jinja to render and macro definitions down to nothing in the config YAML... you do have to be careful with Jinja linebreak supression, i.e.
    ```yaml
    config:
      macros: > # this is a macro!
        {%- macro test() -%}
          testing!
        {%- endmacro -%}
    sources:
      ...
    ```
    could render down to
    ```yaml
    config:
      macros: > # this is a macro!sources:
      ...
    ```
    which will fail with an error about no `sources` defined.

* charset issues when reading / writing non-UTF8 files (thanks Richard!) - this is resolved by enforcing every file read/write to specify UTF8 encoding