### PR TITLE
skip hashing missing optional source files

### DIFF
--- a/earthmover/runs_file.py
+++ b/earthmover/runs_file.py
@@ -158,7 +158,7 @@ class RunsFile:
             if f"$sources.{source.name}" not in node_data.keys():
                 continue
 
-            if not source.is_remote:
+            if not source.is_remote and not (source.optional and source.file==''):
                 sources_hash += self._get_file_hash(source.file)
 
         if sources_hash:

--- a/earthmover/runs_file.py
+++ b/earthmover/runs_file.py
@@ -158,7 +158,7 @@ class RunsFile:
             if f"$sources.{source.name}" not in node_data.keys():
                 continue
 
-            if not source.is_remote and not (source.optional and source.file==''):
+            if source.file and not source.is_remote:
                 sources_hash += self._get_file_hash(source.file)
 
         if sources_hash:

--- a/example_projects/01_simple/earthmover.yaml
+++ b/example_projects/01_simple/earthmover.yaml
@@ -1,5 +1,6 @@
 config:
   output_dir: ./output/
+  state_file: ~/.earthmover.csv
   # memory_limit: 2GB
   # show_stacktrace: True
   # show_graph: True


### PR DESCRIPTION
Fixing a bug Jules found, where earthmover would attempt to hash missing optional sources, causing an error.