### PR TITLE
Feature/structured output

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,34 @@ earthmover run -c path/to/config.yaml --skip-hashing
 ```
 (This makes a one-time run on large input files faster.)
 
+## Structured output of run results
+To produce a JSON file with metadata about the run, invoke earthmover with
+```bash
+earthmover run -c path/to/config.yaml --results-file ./results.json
+```
+For example, for `example_projects/09_edfi/`, a sample results file would be:
+
+```json
+{
+    "started_at": "2023-06-08T10:21:42.445835",
+    "working_dir": "/home/someuser/code/repos/earthmover/example_projects/09_edfi",
+    "config_file": "./earthmover.yaml",
+    "output_dir": "./output/",
+    "row_counts": {
+        "$sources.schools": 6,
+        "$sources.students_anytown": 1199,
+        "$sources.students_someville": 1199,
+        "$destinations.schools": 6,
+        "$transformations.all_students": 2398,
+        "$destinations.students": 2398,
+        "$destinations.studentEducationOrganizationAssociations": 2398,
+        "$destinations.studentSchoolAssociations": 2398
+    },
+    "completed_at": "2023-06-08T10:21:43.118854",
+    "runtime_sec": 0.673019
+}
+```
+
 
 # Tests
 This tool ships with a test suite covering all transformation operations. It can be run with `earthmover -t`, which simply runs the tool on the `config.yaml` and toy data in the `earthmover/tests/` folder. (The DAG is pictured below.) Rendered `earthmover/tests/output/` are then compared against the `earthmover/tests/expected/` output; the test passes only if all files match exactly.

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -92,8 +92,12 @@ def main(argv=None):
         action='store_true',
         help='overwrites `show_stacktrace` config in the config file to true; sets `log_level` to DEBUG'
     )
+    parser.add_argument("--results-file",
+        type=str,
+        help='produces a JSON output file with structured information about run results'
+    )
     
-    _defaults = { "selector":"*", "params": "" }
+    _defaults = { "selector":"*", "params": "", "results_file": "" }
     parser.set_defaults(**_defaults)
 
     args, remaining_argv = parser.parse_known_args()
@@ -151,7 +155,8 @@ def main(argv=None):
             params=args.params,
             force=args.force,
             skip_hashing=args.skip_hashing,
-            cli_state_configs=cli_state_configs
+            cli_state_configs=cli_state_configs,
+            results_file=args.results_file
         )
     except Exception as err:
         logger.exception(err, exc_info=True)

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -7,6 +7,7 @@ import string
 import time
 import yaml
 import jinja2
+import datetime
 import pandas as pd
 
 from string import Template
@@ -38,7 +39,8 @@ class Earthmover:
         params: str = "",
         force: bool = False,
         skip_hashing: bool = False,
-        cli_state_configs: Optional[dict] = None
+        cli_state_configs: Optional[dict] = None,
+        results_file: str = "",
     ):
         self.do_generate = True
         self.force = force
@@ -46,6 +48,7 @@ class Earthmover:
         self.macros = ""
         self.macros_lines = 0
 
+        self.results_file = results_file
         self.config_file = config_file
         self.config_template_string = ""
         self.config_template = None
@@ -90,6 +93,13 @@ class Earthmover:
 
         # Initialize the NetworkX DiGraph
         self.graph = Graph(error_handler=self.error_handler)
+
+        # Initialize a dictionary for tracking run metadata (for structured output)
+        self.start_timestamp = datetime.datetime.now()
+        self.metadata = {
+            "started_at": self.start_timestamp.isoformat(timespec='microseconds'),
+            "row_counts": {}
+        }
 
 
     def load_config_file(self) -> dict:
@@ -314,6 +324,7 @@ class Earthmover:
                 if not node.data:
                     node.execute()  # Sets self.data in each node.
                     node.post_execute()
+                    self.metadata["row_counts"].update({'$'+node.type+'s.'+node.name: len(node.data)})
 
 
     def generate(self, selector):
@@ -434,6 +445,15 @@ class Earthmover:
                 node.num_rows = num_rows
 
             active_graph.draw()
+        
+        ### Create structured output results_file if necessary
+        if self.results_file:
+            self.end_timestamp = datetime.datetime.now()
+            self.metadata.update({"completed_at": self.end_timestamp.isoformat(timespec='microseconds')})
+            self.metadata.update({"runtime_sec": (self.end_timestamp - self.start_timestamp).total_seconds()})
+            with open(self.results_file, 'w') as fp:
+                fp.write(json.dumps(self.metadata, indent=4))
+                fp.close()
 
 
     def test(self, tests_dir):

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -98,6 +98,7 @@ class Earthmover:
         self.start_timestamp = datetime.datetime.now()
         self.metadata = {
             "started_at": self.start_timestamp.isoformat(timespec='microseconds'),
+            "working_dir": os.getcwd(),
             "config_file": self.config_file,
             "output_dir": self.state_configs["output_dir"],
             "row_counts": {}

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -98,6 +98,8 @@ class Earthmover:
         self.start_timestamp = datetime.datetime.now()
         self.metadata = {
             "started_at": self.start_timestamp.isoformat(timespec='microseconds'),
+            "config_file": self.config_file,
+            "output_dir": self.state_configs["output_dir"],
             "row_counts": {}
         }
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -327,7 +327,8 @@ class Earthmover:
                 if not node.data:
                     node.execute()  # Sets self.data in each node.
                     node.post_execute()
-                    self.metadata["row_counts"].update({'$'+node.type+'s.'+node.name: len(node.data)})
+                    if self.results_file:
+                        self.metadata["row_counts"].update({'$'+node.type+'s.'+node.name: len(node.data)})
 
 
     def generate(self, selector):
@@ -456,7 +457,6 @@ class Earthmover:
             self.metadata.update({"runtime_sec": (self.end_timestamp - self.start_timestamp).total_seconds()})
             with open(self.results_file, 'w') as fp:
                 fp.write(json.dumps(self.metadata, indent=4))
-                fp.close()
 
 
     def test(self, tests_dir):


### PR DESCRIPTION
This PR implements the structured output portion of [this issue](https://github.com/edanalytics/earthmover/issues/30). (A separate one will be coming to implement the exit code portion.) It adds the `--results-file` flag which allows you to specify an output to file to which earthmover will write a structured JSON run summary. For example, for `example_projects/09_edfi/`, a sample results file would be:

```json
{
    "started_at": "2023-06-08T10:21:42.445835",
    "working_dir": "/home/someuser/code/repos/earthmover/example_projects/09_edfi",
    "config_file": "./earthmover.yaml",
    "output_dir": "./output/",
    "row_counts": {
        "$sources.schools": 6,
        "$sources.students_anytown": 1199,
        "$sources.students_someville": 1199,
        "$destinations.schools": 6,
        "$transformations.all_students": 2398,
        "$destinations.students": 2398,
        "$destinations.studentEducationOrganizationAssociations": 2398,
        "$destinations.studentSchoolAssociations": 2398
    },
    "completed_at": "2023-06-08T10:21:43.118854",
    "runtime_sec": 0.673019
}
```