### PR TITLE
adding ability to configure the dask tmp_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ config:
   output_dir: ./
   state_file: ~/.earthmover.csv
   log_level: INFO
+  tmp_dir: /tmp
   show_stacktrace: True
   show_graph: True
   macros: >
@@ -101,6 +102,7 @@ config:
   - `WARNING`: output errors and warnings like when the run log is getting long
   - `INFO`: all errors and warnings plus basic information about what `earthmover` is doing: start and stop, how many rows were removed by a `distinct_rows` or `filter_rows` operation, etc. (This is the default `log_level`.)
   - `DEBUG`: all output above, plus verbose details about each transformation step, timing, memory usage, and more. (This `log_level` is recommended for [debugging](#debugging-practices) transformations.)
+* (optional) Specify the `tmp_dir` path to use when dask must spill data to disk. The default is `/tmp`.
 * (optional) Specify whether to show a stacktrace for runtime errors. The default is `False`.
 * (optional) Specify whether or not `show_graph` (default is `False`), which requires [PyGraphViz](https://pygraphviz.github.io/) to be installed and creates `graph.png` and `graph.svg` which are visual depictions of the dependency graph.
 * (optional) Specify Jinja `macros` which will be available within any Jinja template content throughout the project. (This can slow performance.)

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -1,6 +1,7 @@
 import dask
 import json
 import logging
+import tempfile
 import networkx as nx
 import os
 import string
@@ -30,7 +31,7 @@ class Earthmover:
         "show_graph": False,
         "log_level": "INFO",
         "show_stacktrace": False,
-        "tmp_dir": "/tmp",
+        "tmp_dir": tempfile.gettempdir(),
     }
 
     def __init__(self,

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -30,6 +30,7 @@ class Earthmover:
         "show_graph": False,
         "log_level": "INFO",
         "show_stacktrace": False,
+        "tmp_dir": "/tmp",
     }
 
     def __init__(self,
@@ -67,6 +68,7 @@ class Earthmover:
             'show_graph': _state_configs['show_graph'],
             'log_level': _state_configs['log_level'].upper(),
             'show_stacktrace': _state_configs['show_stacktrace'],
+            'tmp_dir': _state_configs['tmp_dir'],
         }
         if 'state_file' in _state_configs.keys():
             self.state_configs.update({'state_file': _state_configs['state_file']})
@@ -397,6 +399,7 @@ class Earthmover:
 
 
         ### Process the graph
+        dask.config.set({'temporary_directory': self.state_configs['tmp_dir']})
         for idx, component in enumerate( nx.weakly_connected_components(active_graph) ):
             self.logger.debug(f"processing component {idx}")
 


### PR DESCRIPTION
When Dask must spill data to disk, it writes files (Parquet, I believe) to a temporary location. This is configurable to Dask via [the `temporary_directory` option](https://github.com/dask/dask/pull/4774), but earthmover was not exposing it.

This update adds an earthmover config `tmp_dir` where you can specify the path Dask should use.