### PR TITLE
Add optional encoding parameter when loading a SAS source.

### DIFF
--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -251,7 +251,7 @@ class FileSource(Source):
             'json'      : lambda file, config: dd.read_json(file, typ=config.get('object_type', "frame"), orient=config.get('orientation', "columns")),
             'jsonl'     : lambda file, config: dd.read_json(file, lines=True),
             'parquet'   : lambda file, _     : dd.read_parquet(file),
-            'sas'       : lambda file, _     : pd.read_sas(file),
+            'sas'       : lambda file, config: pd.read_sas(file, encoding=config.get('encoding', "utf-8")),
             'spss'      : lambda file, _     : pd.read_spss(file),
             'stata'     : lambda file, _     : pd.read_stata(file),
             'xml'       : lambda file, config: pd.read_xml(file, xpath=config.get('xpath', "./*")),


### PR DESCRIPTION
This fixes a bug where numerics in a SAS file are loaded in Pandas as byte-strings. The encoding parameter can be optionally defined in the source.

TODO: Because all FileSources use a Pandas or Dask `read_` method, we should provide a flexible way for the user to pass kwargs to the method. I will look into how we could do this without breaking existing implementations.