### PR TITLE
create results_file path if it does not already exist

### DIFF
--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -458,9 +458,7 @@ class Earthmover:
         if self.results_file:
 
             # create directory if not exists
-            results_dir = os.path.dirname(self.results_file)
-            if not os.path.isdir(results_dir):
-                os.makedirs(results_dir)
+            os.makedirs(os.path.dirname(self.results_file), exist_ok=True)
 
             self.end_timestamp = datetime.datetime.now()
             self.metadata.update({"completed_at": self.end_timestamp.isoformat(timespec='microseconds')})

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -456,6 +456,12 @@ class Earthmover:
         
         ### Create structured output results_file if necessary
         if self.results_file:
+
+            # create directory if not exists
+            results_dir = os.path.dirname(self.results_file)
+            if not os.path.isdir(results_dir):
+                os.makedirs(results_dir)
+
             self.end_timestamp = datetime.datetime.now()
             self.metadata.update({"completed_at": self.end_timestamp.isoformat(timespec='microseconds')})
             self.metadata.update({"runtime_sec": (self.end_timestamp - self.start_timestamp).total_seconds()})

--- a/example_projects/run_all.sh
+++ b/example_projects/run_all.sh
@@ -4,63 +4,63 @@ echo "running all examples..."
 
 echo "  running 01_simple..."
 cd 01_simple/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 02_join..."
 cd ../02_join/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 03_groupby..."
 cd ../03_groupby/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 04_sqlalchemy..."
 cd ../04_sqlalchemy/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 05_ftp..."
 cd ../05_ftp/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 06_subtemplates..."
 cd ../06_subtemplates/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 07_filetypes..."
 cd ../07_filetypes/
-earthmover -f
+earthmover run -f
 rm -rf output/*
 echo "  ... done!"
 
 echo "  running 08_html..."
 cd ../08_html/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 09_edfi..."
 cd ../09_edfi/
-earthmover -f
+earthmover run -f
 rm -f output/*
 echo "  ... done!"
 
 echo "  running 10_jinja..."
 cd ../10_jinja/
-earthmover -f
+earthmover run -f
 rm -rf outputs/*
 echo "  ... done!"
 
 cd ../
-echo "all examples have run. goodbye :)"
+echo "all examples have run, goodbye"


### PR DESCRIPTION
This PR fixes a bug where if the path to the specified results_file does not exist, earthmover would fail instead of just creating it.

I'm also sneaking in a minor tweak to the test suite to suppress earthmover warnings about being invoked without a specific command.