### PR TITLE
switch logic order for checking if source is remote

### DIFF
--- a/earthmover/runs_file.py
+++ b/earthmover/runs_file.py
@@ -158,7 +158,7 @@ class RunsFile:
             if f"$sources.{source.name}" not in node_data.keys():
                 continue
 
-            if source.file and not source.is_remote:
+            if not source.is_remote and source.file:
                 sources_hash += self._get_file_hash(source.file)
 
         if sources_hash:


### PR DESCRIPTION
Fixing a small bug where earthmover would check for a 'file' for remote sources which do not have files, causing an error.