### PR TITLE
Rc/1.0.0  yaml version 2  dask performance improvements

### DIFF
--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -33,6 +33,8 @@ class Earthmover:
         "log_level": "INFO",
         "show_stacktrace": False,
         "tmp_dir": tempfile.gettempdir(),
+        "show_progress": False,
+        "chunksize": 1024 * 1024 * 100,
     }
 
     sources: list = []

--- a/earthmover/node.py
+++ b/earthmover/node.py
@@ -107,7 +107,7 @@ class Node:
 
         # Get lazy row and column counts to display in graph.png.
         if isinstance(self.data, (pd.Series, dd.Series)):
-            self.num_rows, self.num_cols = len(self.data), 1
+            self.num_rows, self.num_cols = self.data.size, 1
         else:
             self.num_rows, self.num_cols = self.data.shape
 

--- a/earthmover/node.py
+++ b/earthmover/node.py
@@ -1,8 +1,10 @@
 import abc
 import dask
+import dask.dataframe as dd
 import jinja2
 import pandas as pd
 
+from dask.diagnostics import ProgressBar
 from typing import List
 
 from earthmover.yaml_parser import YamlMapping
@@ -18,9 +20,7 @@ class Node:
 
     """
     type: str = None
-    allowed_configs: tuple = ('debug', 'expect',)
-
-    CHUNKSIZE = 1024 * 1024 * 100  # 100 MB
+    allowed_configs: tuple = ('debug', 'expect', 'show_progress', 'chunksize')
 
     def __init__(self, name: str, config: YamlMapping, *, earthmover: 'Earthmover'):
         self.name = name
@@ -40,6 +40,13 @@ class Node:
 
         self.expectations: list = None
         self.debug: bool = False
+
+        # Customize internal Dask configs
+        self.chunksize = self.config.get('chunksize', self.earthmover.state_configs["chunksize"])
+
+        # Optional variables for displaying progress and diagnostics.
+        self.show_progress = self.config.get('show_progress', self.earthmover.state_configs["show_progress"])
+        self.progress_bar = None
 
     @abc.abstractmethod
     def compile(self):
@@ -77,6 +84,11 @@ class Node:
             file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
         )
 
+        if self.show_progress:
+            self.logger.info(f"Displaying progress for {self.type} node: {self.name}")
+            self.progress_bar = ProgressBar(dt=1.0)
+            self.progress_bar.__enter__()  # Open context manager manually to avoid with-clause
+
         pass
 
     def post_execute(self):
@@ -88,9 +100,16 @@ class Node:
 
         :return:
         """
+        if self.show_progress:
+            self.progress_bar.__exit__(None, None, None)  # Close context manager manually to avoid with-clause
+
         self.check_expectations(self.expectations)
 
-        self.num_rows, self.num_cols = self.data.shape
+        # Get lazy row and column counts to display in graph.png.
+        if isinstance(self.data, (pd.Series, dd.Series)):
+            self.num_rows, self.num_cols = len(self.data), 1
+        else:
+            self.num_rows, self.num_cols = self.data.shape
 
         if self.debug:
             self.num_rows = dask.compute(self.num_rows)[0]

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -13,7 +13,7 @@ class Destination(Node):
     """
     type: str = 'destination'
     mode: str = None  # Documents which class was chosen.
-    allowed_configs: tuple = ('debug', 'expect', 'source',)
+    allowed_configs: tuple = ('debug', 'expect', 'show_progress', 'chunksize', 'source',)
 
     def __new__(cls, *args, **kwargs):
         return object.__new__(FileDestination)
@@ -30,7 +30,7 @@ class FileDestination(Destination):
     """
     mode: str = 'file'
     allowed_configs: tuple = (
-        'debug', 'expect', 'source',
+        'debug', 'expect', 'show_progress', 'chunksize', 'source',
         'template', 'extension', 'linearize', 'header', 'footer',
     )
 

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -77,5 +77,13 @@ class Operation(Node):
         :param kwargs:
         :return:
         """
-        super().execute()
+        self.error_handler.ctx.update(
+            file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
+        )
+
         pass
+
+    def post_execute(self):
+        raise NotImplementedError(
+            "Operation.post_execute() is not permitted! Data is not persisted within Operations."
+        )

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -62,8 +62,6 @@ class Operation(Node):
         full_name = f"{name}.operations:{config.get('operation')}"
         super().__init__(full_name, config, earthmover=earthmover)
 
-        self.source_data_mapping: dict = None
-
     @abc.abstractmethod
     def execute(self, data: 'DataFrame', *, data_mapping: dict, **kwargs) -> 'DataFrame':
         """

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -67,7 +67,7 @@ class Source(Node):
             )
             self.data = dd.from_pandas(
                 self.data,
-                chunksize=self.CHUNKSIZE
+                chunksize=self.chunksize
             )
 
 

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -22,7 +22,7 @@ class Source(Node):
     type: str = 'source'
     mode: str = None  # Documents which class was chosen.
     is_remote: bool = None
-    allowed_configs: tuple = ('debug', 'expect', 'optional',)
+    allowed_configs: tuple = ('debug', 'expect', 'show_progress', 'chunksize', 'optional',)
 
     def __new__(cls, name: str, config: dict, *, earthmover: 'Earthmover'):
         """
@@ -78,7 +78,7 @@ class FileSource(Source):
     mode: str = 'file'
     is_remote: bool = False
     allowed_configs: tuple = (
-        'debug', 'expect', 'optional',
+        'debug', 'expect', 'show_progress', 'chunksize', 'optional',
         'file', 'type', 'columns', 'header_rows',
         'encoding', 'sheet', 'object_type', 'match', 'orientation', 'xpath',
     )
@@ -272,7 +272,7 @@ class FtpSource(Source):
     mode: str = 'ftp'
     is_remote: bool = True
     allowed_configs: tuple = (
-        'debug', 'expect', 'optional',
+        'debug', 'expect', 'show_progress', 'chunksize', 'optional',
         'connection', 'query',
     )
 
@@ -345,7 +345,7 @@ class SqlSource(Source):
     mode: str = 'sql'
     is_remote: bool = True
     allowed_configs: tuple = (
-        'debug', 'expect', 'optional',
+        'debug', 'expect', 'show_progress', 'chunksize', 'optional',
         'connection', 'query',
     )
 

--- a/earthmover/nodes/transformation.py
+++ b/earthmover/nodes/transformation.py
@@ -7,7 +7,7 @@ class Transformation(Node):
 
     """
     type: str = 'transformation'
-    allowed_configs: tuple = ('debug', 'expect', 'operations', 'source',)
+    allowed_configs: tuple = ('debug', 'expect', 'show_progress', 'chunksize', 'operations', 'source',)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -21,7 +21,6 @@ class JoinOperation(Operation):
 
         # Check joined node
         self.sources = self.error_handler.assert_get_key(self.config, 'sources', dtype=list)
-        self.source_data_mapping = None
 
         self.join_type: str = None
 
@@ -88,11 +87,6 @@ class JoinOperation(Operation):
         """
         super().execute(data, data_mapping=data_mapping, **kwargs)
 
-        self.source_data_mapping = {
-            source: data_mapping[source].data
-            for source in self.sources
-        }
-
         # Build left dataset
         self.left_cols = data.columns
 
@@ -118,7 +112,7 @@ class JoinOperation(Operation):
 
         # Iterate each right dataset
         for source in self.sources:
-            right_data = self.source_data_mapping[source]
+            right_data = data_mapping[source].data
             self.right_cols = right_data.columns
 
             if self.right_keep_cols:
@@ -168,7 +162,6 @@ class UnionOperation(Operation):
         super().__init__(*args, **kwargs)
 
         self.sources = self.error_handler.assert_get_key(self.config, 'sources', dtype=list)
-        self.source_data_mapping = None
 
     def execute(self, data: 'DataFrame', data_mapping: dict, **kwargs):
         """
@@ -177,13 +170,8 @@ class UnionOperation(Operation):
         """
         super().execute(data, data_mapping=data_mapping, **kwargs)
 
-        self.source_data_mapping = {
-            source: data_mapping[source].data
-            for source in self.sources
-        }
-
         for source in self.sources:
-            source_data = self.source_data_mapping[source]
+            source_data = data_mapping[source].data
 
             if set(source_data.columns) != set(data.columns):
                 self.error_handler.throw('dataframes to union do not share identical columns')


### PR DESCRIPTION
This branch incorporates several fixes and improvements to the RC/1.0.0 Yaml Refactor branch:
- Add `show_progress` and `chunksize` as optional state and node configs.
- Update `Destination.data` to reflect the object being written, not the input DataFrame.
- Implement Tom's performance-improvements to `FileDestination`, `JoinOperation`, and `DistinctRowsOperation`.
- Force a `NotImplementedError` when `Operation.post_execute()` is called (as data cannot be persisted at the Operation-level.