### PR TITLE
Update destination.py

### DIFF
--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -110,7 +110,7 @@ class FileDestination(Destination):
         # (meta=... below is how we prevent dask warnings that it can't infer the output data type)
         self.data = (
             self.upstream_sources[self.source].data
-                .astype(str)
+                .astype("string")
                 .fillna('')
                 .map_partitions(lambda x: x.apply(self.render_row, axis=1), meta=pd.Series('str'))
         )

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -110,6 +110,7 @@ class FileDestination(Destination):
         # (meta=... below is how we prevent dask warnings that it can't infer the output data type)
         self.data = (
             self.upstream_sources[self.source].data
+                .astype(str)
                 .fillna('')
                 .map_partitions(lambda x: x.apply(self.render_row, axis=1), meta=pd.Series('str'))
         )


### PR DESCRIPTION
This hotfix addresses a bug I encountered when trying to load assessments into SC using a Snowflake-sourced ID-xwalk. 

```
TypeError: Cannot setitem on a Categorical with a new category (), set the categories first
```

For some reason, a Categorical column in being introduced during processing, and must be converted to a string before filling NAs.