### PR TITLE
fixing typos in docs and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 <summary>Released 2023-05-12</summary>
 
 * bugfix: `config.state`_file was being ignored when specified
-* bugfix: further issues with multi-line `config.macros` - the resolution here (hopefully the last one!) is to pre-load macros (so they can be injected into run-time Jinja contexts) and then just allow the Jinja to render and macro definitions down to nothing in the config YAML... you do have to be careful with Jinja linebreak supression, i.e.
+* bugfix: further issues with multi-line `config.macros` - the resolution here (hopefully the last one!) is to pre-load macros (so they can be injected into run-time Jinja contexts) and then just allow the Jinja to render and macro definitions down to nothing in the config YAML... you do have to be careful with Jinja linebreak suppression, i.e.
     ```yaml
     config:
     macros: > # this is a macro!

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Each source must have a name (which is how it is referenced by transformations a
 * Database sources are supported via [SQLAlchemy](https://www.sqlalchemy.org/). They must specify a database `connection` string and SQL `query` to run.
 * FTP file sources are supported via [ftplib](https://docs.python.org/3/library/ftplib.html). They must specify an FTP `connection` string.
 
-For any source, optionally specify conditions you `expect` data to meet which, if not true for any row, will cause the run to fail with an error. (This can be useful for detecing and rejecting NULL or missing values before processing the data.) The format must be a Jinja expression that returns a boolean value. This is enables casting values (which are all treated as strings) to numeric formats like int and float for numeric comparisons.
+For any source, optionally specify conditions you `expect` data to meet which, if not true for any row, will cause the run to fail with an error. (This can be useful for detecting and rejecting NULL or missing values before processing the data.) The format must be a Jinja expression that returns a boolean value. This is enables casting values (which are all treated as strings) to numeric formats like int and float for numeric comparisons.
 
 The examples above show `user:pass` in the `connection` string, but if you are version-controlling your YAML you must avoid publishing such credentials. Typically this is done via [environment variables](#environment-variable-references) or [command line parameters](#command-line-parameters), which are both supported by this tool. Such environment variable references may be used throughout your YAML (not just in the `sources` section), and are parsed at load time.
 
@@ -543,8 +543,8 @@ Reduce the number of rows by grouping, and add columns with values calculated ov
 ```
 Valid aggregation functions are
 * `count()` or `size()` - the number of rows in each group
-* `min(column)` - the minumum (numeric) value in `column` for each group
-* `str_min(column)` - the minumum (string) value in `column` for each group
+* `min(column)` - the minimum (numeric) value in `column` for each group
+* `str_min(column)` - the minimum (string) value in `column` for each group
 * `max(column)` - the maximum (numeric) value in `column` for each group
 * `str_max(column)` - the maximum (string) value in `column` for each group
 * `sum(column)` - the sum of (numeric) values in `column` for each group
@@ -859,7 +859,7 @@ Generally you should separate the mappings, transformations, and structure of yo
 
 When dealing with sensitive source data, you may have to comply with security protocols, such as referencing sensitive data from a network storage location rather than copying it to your own computer. In this situation, option 2 above is a good choice.
 
-To facilitate [operationalization]($operationalization-practices), we recommended using [environment vairables](#environment-variable-references) or [command-line parameters](#command-line-parameters) to pass input and output directories and filenames to `earthmover`, rather than hard-coding them into `earthmover.yaml`. For example, rather than
+To facilitate [operationalization]($operationalization-practices), we recommended using [environment variables](#environment-variable-references) or [command-line parameters](#command-line-parameters) to pass input and output directories and filenames to `earthmover`, rather than hard-coding them into `earthmover.yaml`. For example, rather than
 ```yaml
 config:
   output_dir: path/to/outputs/
@@ -938,7 +938,7 @@ When developing your transformations, it can be helpful to
 You can remove these settings once your `earthmover` project is ready for operationalization.
 
 ## Operationalization practices
-Typically `earthmover` is used when the same (or simlar) data transformations must be done repeatedly. (A one-time data transformation task may be more easily done with [SQLite](https://www.sqlite.org/index.html) or a similar tool.) When deploying/operationalizing `earthmover`, whether with a simple scheduler like [cron](https://en.wikipedia.org/wiki/Cron) or an orchestration tool like [Airflow](https://airflow.apache.org/) or [Dagster](https://dagster.io/), consider
+Typically `earthmover` is used when the same (or similar) data transformations must be done repeatedly. (A one-time data transformation task may be more easily done with [SQLite](https://www.sqlite.org/index.html) or a similar tool.) When deploying/operationalizing `earthmover`, whether with a simple scheduler like [cron](https://en.wikipedia.org/wiki/Cron) or an orchestration tool like [Airflow](https://airflow.apache.org/) or [Dagster](https://dagster.io/), consider
 * specifying conditions you `expect` your [sources](#sources) to meet, so `earthmover` will fail on source data errors
 * specifying `config` &raquo; `log_level: INFO` and monitoring logs for phrases like
   > `distinct_rows` operation removed NN duplicate rows

--- a/earthmover/tests/expected/species_count_by_zoo.jsonl
+++ b/earthmover/tests/expected/species_count_by_zoo.jsonl
@@ -1,4 +1,4 @@
-{ "entity": "zoo", "name": "Cincinnatti Zoo and Botanical Garden", "species_count": 8 }
+{ "entity": "zoo", "name": "Cincinnati Zoo and Botanical Garden", "species_count": 8 }
 { "entity": "zoo", "name": "Denver Zoo", "species_count": 8 }
 { "entity": "zoo", "name": "Dallas Zoo", "species_count": 0 }
 { "entity": "zoo", "name": "Oregon Zoo", "species_count": 0 }

--- a/earthmover/tests/sources/zoos.csv
+++ b/earthmover/tests/sources/zoos.csv
@@ -1,5 +1,5 @@
 id,name,city,state,date_founded
-1,Cincinnatti Zoo and Botanical Garden,Cincinnatti,OH,Jan 1 1875
+1,Cincinnati Zoo and Botanical Garden,Cincinnati,OH,Jan 1 1875
 2,Denver Zoo,Denver,CO,Jan 1 1896
 3,Dallas Zoo,Dallas,TX,Jan 1 1888
 4,Oregon Zoo,Portland,OR,Jan 1 1888

--- a/example_projects/07_filetypes/earthmover.yaml
+++ b/example_projects/07_filetypes/earthmover.yaml
@@ -31,7 +31,7 @@ sources:
       - salary
       - title
       - comments
-    # ^ this is necessary becase the metadata isn't present in the orc file, so Pandas gives default column names
+    # ^ this is necessary because the metadata isn't present in the orc file, so Pandas gives default column names
   users3:
     file: https://raw.githubusercontent.com/Teradata/kylo/master/samples/sample-data/csv/userdata3.csv
     # ^ from https://github.com/Teradata/kylo/tree/master/samples/sample-data/csv


### PR DESCRIPTION
This PR fixes typographical errors in earthmover's documentation and comments. It's based on [this PR](https://github.com/edanalytics/earthmover/pull/58) which we've decided to close without including the tooling/configuration in that PR into earthmover.