### PR TITLE
Remove hashing on file source directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * feature: add `optional_fields` key to all Sources to add optional empty columns when missing from schema
 * internal: force-cast a dataframe to string-type after loading a Source
 * internal: force-cast a dataframe to string-type before writing as a Destination
+* internal: removed attempted directory-hashing when a source is a directory (i.e., Parquet)
 </details>
 
 ### v0.2.0

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -184,6 +184,11 @@ class Earthmover:
                     "forcing regenerate, since some sources are remote (and we cannot know if they changed)"
                 )
 
+            elif any(hasattr(source, 'file') and os.path.isdir(source.file) for source in self.sources):
+                self.logger.info(
+                    "forcing regenerate, since some file sources are directories (and cannot be efficiently hashed)"
+                )
+
             elif self.force:
                 self.logger.info("forcing regenerate")
 

--- a/earthmover/runs_file.py
+++ b/earthmover/runs_file.py
@@ -158,7 +158,7 @@ class RunsFile:
             if f"$sources.{source.name}" not in node_data.keys():
                 continue
 
-            if not source.is_remote and source.file:
+            if not source.is_remote and source.file and not os.path.isdir(source.file):
                 sources_hash += self._get_file_hash(source.file)
 
         if sources_hash:


### PR DESCRIPTION
This PR updates hashing logic to skip when a Source file is a directory (i.e., Parquet). See this [Monday ticket](https://educationanalytics.monday.com/boards/6058716254/pulses/6103720040).

Should we consider an approach where Parquet directories are actually hashed? How can this be done efficiently?