### PR TITLE
adding fromjson() function to Jinja

### DIFF
--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -1,5 +1,6 @@
 import jinja2
 import hashlib
+import json
 import os
 
 from sys import exc_info
@@ -129,5 +130,6 @@ def build_jinja_template(template_string: str, macros: str = ""):
     ).from_string(macros.strip() + template_string)
 
     template.globals['md5'] = lambda x: hashlib.md5(x.encode('utf-8')).hexdigest()
+    template.globals['fromjson'] = lambda x: json.loads(x)
 
     return template


### PR DESCRIPTION
When source data is _nested_ JSON, earthmover makes a column per _top level_ key, with values as strings... which may themselves be JSON. This PR adds a `fromjson()` function which can be called from within Jinja templates to parse such JSON strings into actual objects which can be traversed or used. (Name choice of `fromjson` is [based on dbt](https://docs.getdbt.com/reference/dbt-jinja-functions/fromjson).)

In the future, we could consider providing a more extensible way for users to specify their own functions to be injected into Jinja, but this small addition unblocks some development of the [LIF translator](https://github.com/BMGF-LIF/lif-translator/) for now.