### PR TITLE
Feature/project composition  refactor yaml mapping

### DIFF
--- a/earthmover/node.py
+++ b/earthmover/node.py
@@ -33,7 +33,7 @@ class Node:
         self.error_handler: 'ErrorHandler' = earthmover.error_handler
 
         self.error_handler.ctx.update(
-            file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
+            file=self.config.__file__, line=self.config.__line__, node=self, operation=None
         )
 
         self.upstream_sources: Dict[str, Optional['Node']] = {}
@@ -61,7 +61,7 @@ class Node:
         :return:
         """
         self.error_handler.ctx.update(
-            file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
+            file=self.config.__file__, line=self.config.__line__, node=self, operation=None
         )
 
         # Verify all configs provided by the user are specified for the node.
@@ -87,7 +87,7 @@ class Node:
         :return:
         """
         self.error_handler.ctx.update(
-            file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
+            file=self.config.__file__, line=self.config.__line__, node=self, operation=None
         )
 
         # Turn on the progress bar manually.

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -14,7 +14,7 @@ class Operation(Node):
     """
 
     """
-    type: str = "operation"
+    type: str = "transformation"
     allowed_configs: Tuple[str] = ('operation', 'repartition',)
 
     def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):

--- a/earthmover/nodes/operation.py
+++ b/earthmover/nodes/operation.py
@@ -79,7 +79,7 @@ class Operation(Node):
         :return:
         """
         self.error_handler.ctx.update(
-            file=self.earthmover.config_file, line=self.config.__line__, node=self, operation=None
+            file=self.config.__file__, line=self.config.__line__, node=self, operation=None
         )
 
         pass

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -36,9 +36,9 @@ class YamlMapping(dict):
 
         for key, val in self.items():
             if isinstance(val, (list, tuple)):
-                output_dict[key] = list(map(_recurse_to_dict, val))
+                output_dict[key] = list(map(self._recurse_to_dict, val))
             else:
-                output_dict[key] = _recurse_to_dict(val)
+                output_dict[key] = self._recurse_to_dict(val)
 
         return output_dict
 


### PR DESCRIPTION
This PR makes the following changes to the `feature/project_composition` branch:

- Add `__file__` as a YamlMapping attribute based on the template file it is parsed from
- Move dict-merging logic into YamlMapping as `YamlMapping.update()`
  - Update file and line metadata during merges
- Move dict-write logic into YamlMapping as `YamlMapping.to_disk()`
- Minor bugfix to operation name referencing in error output