### PR TITLE
Feature/project composition into Release Candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The general structure of the YAML involves the following sections:
 1. `version`, with required value `2` (Earthmover 0.2.x and later)
 1. [`config`](#config), which specifies options like the logging level and parameter defaults
 1. [`definitions`](#definitions) is an *optional* way to specify reusable values and blocks
+1. [`packages`](#packages), an *optional* way to import and build on existing projects
 1. [`sources`](#sources), where each source file is listed with details like the number of header rows
 1. [`transformations`](#transformations), where source data can be transformed in various ways
 1. [`destinations`](#destinations), where transformed data can be mapped to JSON templates and Ed-Fi endpoints and sent to an Ed-Fi API
@@ -190,6 +191,23 @@ transformations:
         columns:
           school_year: *date_to_year
 ```
+
+
+### **`packages`**
+The `packages` section of the [YAML configuration](#yaml-configuration) is an optional section you can use to specify packages &ndash; other `earthmover` projects from a local directory or GitHub &ndash; to import and build upon exisiting code. See [Project Composition](#project-composition) for more details and considerations.
+
+A sample `packages` section is shown here; the options are explained below.
+```yaml
+packages:
+  year_end_assessment:
+    git: "https://github.com/edanalytics/earthmover_edfi_bundles.git"
+    subdirectory: "assessments/assessment_name"
+  student_id_macros:
+    local: "path/to/student_id_macros"
+```
+Each package must have a name (which will be used to name the folder where it is installed in `/packages`) such as `year_end_assessment` or `student_id_macros` in this example. Two sources of `packages` are currently supported:
+* GitHub packages: Specify the URL of the repository containing the package. If the package YAML configuration is not in the top level of the repository, include the path to the folder with the the optional `subdirectory`.
+* Local packages: Specify the relative or absolute path to the folder containing the package YAML configuration.
 
 
 ### **`sources`**
@@ -781,6 +799,79 @@ For example, for `example_projects/09_edfi/`, a sample results file would be:
 }
 ```
 
+## **Project composition**
+An `earthmover` project can import and build upon other `earthmover` projects by importing them as packages, similar to the concept of dbt packages. When a project uses a package, any elements of the package can be overwritten by the project. This allows you to use majority of the code from a package and specify only the necessary changes in the project.
+
+To install the packages specified in your [YAML Configuration](#yaml-configuration), run `earthmover deps`. Packages will be installed in a nested format in a `packages/` directory. Once packages are installed, `earthmover` can be run as usual. If you make any changes to the packages, run `earthmover deps` again to install the latest version of the packages. 
+
+<details>
+<summary>Example of a composed project</summary>
+
+```yaml
+# projA/earthmover.yml                     # projA/pkgB/earthmover.yml
+config:                                    config:
+  show_graph: True                           parameter_defaults:
+  output_dir: ./output                         DO_FILTERING: "False"
+
+packages:                                  sources:
+  pkgB:                                      source1:
+    local: pkgB                                file: ./seeds/source1.csv
+                                               header_rows: 1
+sources:                                     source2:
+  source1:                                     file: ./seeds/source2.csv
+    file: ./seeds/source1.csv                  header_rows: 1
+    header_rows: 1                                           
+                                           transformations:
+destinations:                                trans1:
+  dest1:                                       ...
+    source: $transformations.trans1
+    template: ./templates/dest1.jsont      destinations:
+                                             dest1:
+                                               source: $transformations.trans1
+                                               template: ./templates/dest1.jsont
+                                             dest2:
+                                               source: $sources.source2
+                                               template: ./templates/dest2.jsont
+```
+Composed results:
+```yaml
+config:
+  show_graph: True
+  output_dir: ./output 
+  parameter_defaults:
+    DO_FILTERING: "False"
+
+packages:
+  pkgB:
+    local: pkgB
+
+sources:
+  source1:
+    file: ./seeds/source1.csv
+    header_rows: 1  
+  source2: 
+    file: ./packages/pkgB/seeds/source2.csv
+    header_rows: 1    
+    
+transformations:
+  trans1:
+    ...
+
+destinations:
+  dest1:
+    source: $transformations.trans1
+    template: ./templates/dest1.jsont
+  dest2:
+    source: $sources.source2
+    template: ./packages/pkgB/templates/dest2.jsont
+```
+</details>
+
+### Project Composition Considerations
+There is no limit to the number of packages that can be imported and no limit to how deeply they can be nested (i.e. packages can import other packages). However, there are a few things to keep in mind with using multiple packages.
+* If multiple packages at the same level (e.g. `projA/packages/pkgB` and `projA/packages/pkgC`, not `projA/packages/pkgB/packages/pkgC`) include same-named nodes, the package specified later in the `packages` list will overwrite. If the node is also specified in the top-level project, its version of the node will overwrite as usual.
+* A similar limitation exists for macros &ndash; a single definition of each macro will be applied everywhere in the project and packages using the same overwrite logic used for the nodes. When you are creating projects that are likely to be used as packages, consider including a namespace in the names of macros with more common operations, such as `assessment123_filter()` instead of the more generic `filter()`. 
+
 
 # Tests
 This tool ships with a test suite covering all transformation operations. It can be run with `earthmover -t`, which simply runs the tool on the `config.yaml` and toy data in the `earthmover/tests/` folder. (The DAG is pictured below.) Rendered `earthmover/tests/output/` are then compared against the `earthmover/tests/expected/` output; the test passes only if all files match exactly.
@@ -831,7 +922,7 @@ The [state feature](#state) adds some overhead, as hashes of input data and JSON
 # Best Practices
 In this section we outline some suggestions for best practices to follow when using `earthmover`, based on our experience with the tool. Many of these are based on best practices for using [dbt](https://www.getdbt.com/), to which `earthmover` is similar, although `earthmover` operates on dataframes rather than database tables.
 
-# Project Structure Practices
+## Project Structure Practices
 A typical `earthmover` project might have a structure like this:
 ```
 project/

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -179,6 +179,7 @@ def main(argv=None):
             if args.selector != '*':
                 em.logger.info("selector is ignored for compile-only run.")
 
+            em.merge_packages()
             em.build_graph()
             em.compile()
             em.logger.info("looks ok")
@@ -191,6 +192,7 @@ def main(argv=None):
             em.logger.warning("[no command specified; proceeding with `run` but we recommend explicitly giving a command]")
         try:
             em.logger.info("starting...")
+            em.merge_packages()
             em.generate(selector=args.selector)
             em.logger.info("done!")
         except Exception as e:

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -162,7 +162,18 @@ def main(argv=None):
         logger.exception(err, exc_info=True)
         raise  # Avoids linting error
 
-    if args.command == 'compile':
+    if args.command == 'deps':
+        em.logger.info(f"installing packages...")
+        try:
+            if args.selector != '*':
+                em.logger.info("selector is ignored for package install.")
+            em.deps()
+            em.logger.info("done!")
+        except Exception as e:
+            logger.exception(e, exc_info=em.state_configs['show_stacktrace'])
+            raise
+
+    elif args.command == 'compile':
         em.logger.info(f"compiling project...")
         try:
             if args.selector != '*':

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -479,6 +479,14 @@ class Earthmover:
             )
             os.makedirs(packages_dir, exist_ok=True)
 
+        # Check for cycles in the package graph
+        if not nx.is_directed_acyclic_graph(self.package_graph):
+            _cycle = nx.find_cycle(self.package_graph)
+            self.error_handler.throw(
+                f"The package graph has a cycle! Installation stopped. Cycle: {_cycle}"
+            )
+            raise
+
         for package_name in package_subgraph.successors(root_node):
             package_node = self.package_graph.nodes[package_name]
             # Install packages if necessary, or retrieve path to package yaml file

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -442,7 +442,7 @@ class Earthmover:
         self.user_configs = self.package_graph.nodes['root']['package'].package_yaml
         
         # Output merged yaml file
-        with open("./merged_earthmover.yml", "w") as f:
+        with open("./earthmover_composed.yml", "w") as f:
             yaml.safe_dump(json.loads(json.dumps(self.user_configs, ensure_ascii=True)), f, default_flow_style=False)
 
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -1,8 +1,6 @@
 import git
 import os
 import shutil
-import yaml
-import json
 from typing import Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from earthmover.earthmover import Earthmover
@@ -109,9 +107,11 @@ class Package:
 
         # Replace relative paths for any map files in map_values operations
         for transformation in self.error_handler.assert_get_key(yaml_mapping, 'transformations', dtype=dict, required=False, default={}):
-            for operation in self.error_handler.assert_get_key(yaml_mapping[transformation]['operations'], operation, dtype=[dict], required=False, default=[]):
+            operation_num = 0
+            for operation in self.error_handler.assert_get_key(yaml_mapping['transformations'][transformation], 'operations', dtype=list, required=False, default=[]):
                 if operation['operation'] == 'map_values' and not os.path.isabs(operation['map_file']):
-                    yaml_mapping['transformations'][transformation]['operations'][operation]['map_file'] = os.path.join(self.package_path, operation['map_file'].strip('./'))
+                    yaml_mapping['transformations'][transformation]['operations'][operation_num]['map_file'] = os.path.join(self.package_path, operation['map_file'].strip('./'))
+                operation_num += 1
 
         self.package_yaml = yaml_mapping
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -105,7 +105,7 @@ class LocalPackage(Package):
 
     def install(self, packages_dir):
         """
-        Creates a symlink (if allowed) or makes a copy of a local package directory into <project>/packages.
+        Makes a copy of a local package directory into <project>/packages.
         :return:
         """
         super().install(packages_dir)
@@ -118,10 +118,7 @@ class LocalPackage(Package):
             )
             raise
 
-        try:
-            os.symlink(source_path, self.package_path, target_is_directory=True)
-        except OSError:
-            shutil.copytree(source_path, self.package_path)
+        shutil.copytree(source_path, self.package_path)
 
         return super().installed_package_config()
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -21,6 +21,7 @@ class Package:
         :param name:
         :param config:
         :param earthmover:
+        :param package_path:
         """
         if 'local' in config:
             return object.__new__(LocalPackage)

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -62,6 +62,7 @@ class Package:
                 shutil.rmtree(self.package_path)
             else:
                 os.remove(self.package_path)
+                
 
     def installed_package_config(self):
         """

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -109,7 +109,7 @@ class Package:
         for transformation in self.error_handler.assert_get_key(yaml_mapping, 'transformations', dtype=dict, required=False, default={}):
             operation_num = 0
             for operation in self.error_handler.assert_get_key(yaml_mapping['transformations'][transformation], 'operations', dtype=list, required=False, default=[]):
-                if operation['operation'] == 'map_values' and not os.path.isabs(operation['map_file']):
+                if operation['operation'] == 'map_values' and 'map_file' in operation and not os.path.isabs(operation['map_file']):
                     yaml_mapping['transformations'][transformation]['operations'][operation_num]['map_file'] = os.path.join(self.package_path, operation['map_file'].strip('./'))
                 operation_num += 1
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -14,7 +14,7 @@ class Package:
     """
     mode: str = None
 
-    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None, package_config_file: Optional[str] = None):
+    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None):
         """
         Logic for assigning packages to their respective classes.
 
@@ -37,15 +37,16 @@ class Package:
             )
             raise
     
-    def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None, package_config_file: Optional[str] = None):
+    def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None):
         self.name: str = name
         self.config: 'YamlMapping' = config
         self.earthmover: 'Earthmover' = earthmover
         self.package_path: str = package_path
-        self.package_config_file: str = package_config_file
 
         self.logger: 'Logger' = earthmover.logger
         self.error_handler: 'ErrorHandler' = earthmover.error_handler
+
+        self.package_config: dict = None
 
 
     def install(self, packages_dir):
@@ -69,8 +70,7 @@ class Package:
         for file in ['earthmover.yaml', 'earthmover.yml']:
             test_file = os.path.join(self.package_path, file)
             if os.path.isfile(test_file):
-                self.package_config_file = test_file
-                return
+                return test_file
 
         self.error_handler.throw(
             f"config file not found for package '{self.name}'. Ensure the package has a file named 'earthmover.yaml' or 'earthmover.yml' in the root directory."
@@ -117,9 +117,7 @@ class LocalPackage(Package):
         except OSError:
             shutil.copytree(source_path, self.package_path)
 
-        super().installed_package_config()
-
-        return self.package_config_file
+        return super().installed_package_config()
 
 
 class GitHubPackage(Package):
@@ -157,6 +155,4 @@ class GitHubPackage(Package):
         else:
             git.Repo.clone_from(source_path, self.package_path)
 
-        super().installed_package_config()
-
-        return self.package_config_file
+        return super().installed_package_config()

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -1,0 +1,144 @@
+import git
+import os
+import shutil
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from earthmover.earthmover import Earthmover
+    from earthmover.yaml_parser import YamlMapping
+    from earthmover.error_handler import ErrorHandler
+    from logging import Logger
+
+class Package:
+    """
+
+    """
+    mode: str = None
+
+    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
+        """
+        Logic for assigning packages to their respective classes.
+
+        :param name:
+        :param config:
+        :param earthmover:
+        """
+        if 'local' in config:
+            return object.__new__(LocalPackage)
+
+        elif 'git' in config:
+            return object.__new__(GitHubPackage)
+
+        else:
+            earthmover.error_handler.throw(
+                "packages must specify either a `local` folder path or a `git` package URL"
+            )
+            raise
+    
+    def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
+        self.name: str = name
+        self.config: 'YamlMapping' = config
+        self.earthmover: 'Earthmover' = earthmover
+
+        self.logger: 'Logger' = earthmover.logger
+        self.error_handler: 'ErrorHandler' = earthmover.error_handler
+
+        self.destination_path: str = None
+
+    def install(self, packages_dir):
+        """
+
+        """
+        self.logger.info(f"installing '{self.name}'...")
+        self.destination_path = os.path.join(packages_dir, self.name)
+
+        if os.path.lexists(self.destination_path):
+            if not os.path.islink(self.destination_path):
+                shutil.rmtree(self.destination_path)
+            else:
+                os.remove(self.destination_path)
+
+    def installed_package_config(self):
+        """
+        Find the Earthmover config file for the installed package.
+        TODO: allow the config filepath to be specified for the package rather than requiring a default location and name
+        :return:
+        """
+        for file in ['earthmover.yaml', 'earthmover.yml']:
+            test_file = os.path.join(self.destination_path, file)
+            if os.path.isfile(test_file):
+                return test_file
+
+        self.error_handler.throw(
+            f"config file not found for package '{self.name}'. Ensure the package has a file named 'earthmover.yaml' or 'earthmover.yml' in the root directory."
+        )
+        raise
+
+
+class LocalPackage(Package):
+    """
+
+    """
+    mode: str = 'local'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def install(self, packages_dir):
+        """
+        Creates a symlink (if allowed) or makes a copy of a local package directory into <project>/packages.
+        :return:
+        """
+        super().install(packages_dir)
+
+        source_path = self.error_handler.assert_get_key(self.config, 'local', dtype=str, required=False)
+
+        if not os.path.exists(source_path):
+            self.error_handler.throw(
+                f"Local package '{self.name}' not found: verify that the path is correct"
+            )
+            raise
+
+        try:
+            os.symlink(source_path, self.destination_path, target_is_directory=True)
+        except OSError:
+            shutil.copytree(source_path, self.destination_path)
+
+        return super().installed_package_config()
+
+
+class GitHubPackage(Package):
+    """
+
+    """
+    mode: str = 'git'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def install(self, packages_dir):
+        """
+        Clones a GitHub repository into <project>/packages.
+        If a subdirectory is specified, clone the repository into a temporary folder and copy the desired subdirectory into <project>/packages.
+        :return:
+        """
+        super().install(packages_dir)
+
+        source_path = self.error_handler.assert_get_key(self.config, 'git', dtype=str, required=False)
+
+        if 'subdirectory' in self.config:
+            subdirectory = self.error_handler.assert_get_key(self.config, 'subdirectory', dtype=str, required=False)
+
+            tmp_destination_path = os.path.join(packages_dir, 'tmp_git')
+            os.mkdir(tmp_destination_path)
+
+            repo = git.Repo.clone_from(source_path, tmp_destination_path)
+
+            subdirectory_path = os.path.join(repo.working_tree_dir, subdirectory)
+            shutil.copytree(subdirectory_path, self.destination_path)
+
+            git.rmtree(repo.working_tree_dir)
+
+        else:
+            git.Repo.clone_from(source_path, self.destination_path)
+
+        return super().installed_package_config()

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -68,13 +68,18 @@ class Package:
         Find the Earthmover config file for the installed package.
         TODO: allow the config filepath to be specified for the package rather than requiring a default location and name
         """
+        if not os.path.isdir(self.package_path):
+            self.error_handler.throw(
+                f"The package '{self.name}' has not been installed. Run an 'earthmover deps' command to install packages."
+            )
+        
         for file in ['earthmover.yaml', 'earthmover.yml']:
             test_file = os.path.join(self.package_path, file)
             if os.path.isfile(test_file):
                 return test_file
 
         self.error_handler.throw(
-            f"config file not found for package '{self.name}'. Ensure the package has a file named 'earthmover.yaml' or 'earthmover.yml' in the root directory."
+            f"Config file not found for package '{self.name}'. Ensure the package has a file named 'earthmover.yaml' or 'earthmover.yml' in the root directory."
         )
         raise
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -43,6 +43,7 @@ class Package:
         self.error_handler: 'ErrorHandler' = earthmover.error_handler
 
         self.destination_path: str = None
+        self.package_config_file: str = None
 
     def install(self, packages_dir):
         """
@@ -61,12 +62,12 @@ class Package:
         """
         Find the Earthmover config file for the installed package.
         TODO: allow the config filepath to be specified for the package rather than requiring a default location and name
-        :return:
         """
         for file in ['earthmover.yaml', 'earthmover.yml']:
             test_file = os.path.join(self.destination_path, file)
             if os.path.isfile(test_file):
-                return test_file
+                self.package_config_file = test_file
+                return
 
         self.error_handler.throw(
             f"config file not found for package '{self.name}'. Ensure the package has a file named 'earthmover.yaml' or 'earthmover.yml' in the root directory."
@@ -103,7 +104,9 @@ class LocalPackage(Package):
         except OSError:
             shutil.copytree(source_path, self.destination_path)
 
-        return super().installed_package_config()
+        super().installed_package_config()
+
+        return self.package_config_file
 
 
 class GitHubPackage(Package):
@@ -141,4 +144,6 @@ class GitHubPackage(Package):
         else:
             git.Repo.clone_from(source_path, self.destination_path)
 
-        return super().installed_package_config()
+        super().installed_package_config()
+
+        return self.package_config_file

--- a/example_projects/11_composition/earthmover.yaml
+++ b/example_projects/11_composition/earthmover.yaml
@@ -1,0 +1,36 @@
+version: 2
+
+config:
+  log_level: DEBUG
+  output_dir: ./output/
+
+
+packages: 
+  edfi_example_project:
+    local: '../09_edfi/'
+
+
+sources:
+  # this is fake data!
+  schools:
+    file: ./sources/schools.csv
+    header_rows: 1
+    columns:
+      - district_id
+      - school_id
+      - school_name
+      - low_grade
+      - high_grade
+      - address
+      - city
+      - state
+      - zip
+      - telephone
+
+
+destinations:
+  schools:
+    source: $sources.schools
+    template: ./templates/school.jsont
+    extension: jsonl
+    linearize: True

--- a/example_projects/11_composition/sources/schools.csv
+++ b/example_projects/11_composition/sources/schools.csv
@@ -1,0 +1,7 @@
+district_id,school_id,school_name,low_grade,high_grade,address,city,state,zip,telephone
+255901,15628,Someville Academy of Science,7,12,51 Main St.,Someville,IA,53722,815-555-0122
+255901,15631,Someville Academy of Mathematics,7,12,794 Commerce Ave.,Someville,IA,53722,815-555-0186
+255901,15632,Someville Prepatory Academy,1,6,5018 Fair Oaks Dr.,Someville,IA,53722,815-555-0172
+255901,60918,Anytown Achievement High East,9,12,8510 Center Ave.,Anytown,IA,53763,303-555-0124
+255901,60919,Anytown Achievement High West,9,12,58 Periwinkle St.,Anytown,IA,53763,303-555-0199
+255901,60920,Anytown Achievement High Central,9,12,418 Town Line Rd.,Anytown,IA,53763,303-555-0171

--- a/example_projects/11_composition/templates/school.jsont
+++ b/example_projects/11_composition/templates/school.jsont
@@ -1,0 +1,42 @@
+{
+    "localEducationAgencyReference": {
+      "localEducationAgencyId": {{district_id}}
+    },
+    "schoolId": {{school_id}},
+    "nameOfInstitution": "{{school_name}}",
+    "shortNameOfInstitution": "{{school_name}}",
+    "addresses": [
+      {
+        "addressTypeDescriptor": "uri://ed-fi.org/AddressTypeDescriptor#Physical",
+        "city": "{{city}}",
+        "latitude": "",
+        "longitude": "",
+        "postalCode": "{{zip}}",
+        "stateAbbreviationDescriptor": "uri://ed-fi.org/StateAbbreviationDescriptor#{{state}}",
+        "streetNumberName": "{{address}}",
+        "periods": []
+      }
+    ],
+    "educationOrganizationCategories": [
+      {
+        "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"
+      }
+    ],
+    "identificationCodes": [],
+    "institutionTelephones": [
+      {
+        "institutionTelephoneNumberTypeDescriptor": "uri://ed-fi.org/InstitutionTelephoneNumberTypeDescriptor#Main",
+        "telephoneNumber": "{{telephone}}"
+      } 
+    ],
+    "internationalAddresses": [],
+    "schoolCategories": [],
+    "gradeLevels": [
+      {% set grade_mapping = { 1:"First", 2:"Second", 3:"Third", 4:"Fourth", 5:"Fifth", 6:"Sixth", 7:"Seventh", 8:"Eighth", 9:"Ninth", 10:"Tenth", 11:"Eleventh", 12:"Twelfth",  } %}
+      {% for grade in range(low_grade|int, high_grade|int) %}
+      {
+        "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#{{grade_mapping[grade]}} grade"
+      }{% if not loop.last %},{% endif %}
+      {% endfor %}
+    ]
+}

--- a/example_projects/run_all.sh
+++ b/example_projects/run_all.sh
@@ -62,5 +62,12 @@ earthmover run -f
 rm -rf outputs/*
 echo "  ... done!"
 
+echo "  running 11_composition..."
+cd ../11_composition/
+earthmover deps
+earthmover run -f
+rm -rf outputs/*, packages/*
+echo "  ... done!"
+
 cd ../
 echo "all examples have run, goodbye"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 wheel
 aiohttp>=3.8.1
 dask[dataframe]>=2022.2.0
+GitPython>=3.1.40
 Jinja2>=2.11.3
 networkx>=2.6.3
 pandas>=1.3.5


### PR DESCRIPTION
## Description & motivation
This PR allows Earthmover projects to be "composable", allowing developers to import and build on existing projects/packages/bundles. 

## Tests and QC done:
I tested this on a Jeffco NWEA-MAP Earthmover project and matched the result to a past run of a locally modified version of the NWEA-MAP bundle. I did further testing of multiple packages, macro handling, and relative paths using this test bundle
[earthmover_composition_testing.zip](https://github.com/edanalytics/earthmover/files/14590539/earthmover_composition_testing.zip)

## Future ToDos and Questions:
- We currently use a `BUNDLE_DIR` parameter to specify relative paths in most bundles. For those bundles to be used as packages, any filepaths will need to be either relative to the location of the `earthmover.yaml` file (ex. `./seeds/assessments.csv` with our typical folder structure) or entirely specified as parameters similar to how `INPUT_FILE` is typically handled now. **This change will need to be made in order for current bundles to be used as packages.**
- There are some limitations/considerations noted in the readme around being aware that the ordering of packages has an impact on the order of the merge, with later packages overwriting earlier ones. This would only affect projects where two packages are overwriting the same node. Namespacing macros is also recommended to make sure the correct macro is applied to each package.
- The function that handles replacing relative filepaths in the package yaml (`package.load_package_yaml()`) works but will need to be updated if there are future changes to earthmover that would allow filepaths to be provided in new operations or under different keys. It could be rewritten to be more robust.