### PR TITLE
Rc/0.3.0  refactor build graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <details>
 
 <summary>Released TODO</summary>
+
+* feature: add project composition using `packages` keyword in template file (see README)
 * feature: `GroupByWithRankOperation` cumulatively sums record counts by group-by columns
 * feature: setting `log_level: DEBUG` in template configs or setting `debug: True` for a node displays the head of the node mid-run 
 * feature: add `optional_fields` key to all Sources to add optional empty columns when missing from schema
@@ -10,6 +12,9 @@
 * internal: force-cast a dataframe to string-type before writing as a Destination
 * internal: remove attempted directory-hashing when a source is a directory (i.e., Parquet)
 * internal: refactor project to standardize import paths for Node and Operation
+* internal: add `Node.full_name` attribute and `Node.set_upstream_source()` method
+* internal: unify graph-building into compilation
+* internal: refactor compilation and execution code for cleanliness
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * internal: add `Node.full_name` attribute and `Node.set_upstream_source()` method
 * internal: unify graph-building into compilation
 * internal: refactor compilation and execution code for cleanliness
+* internal: unify `Node.compile()` into initialization to ease Node development
 
 </details>
 

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -190,8 +190,8 @@ def main(argv=None):
 
         try:
             em.merge_packages()
-            em.build_graph()
             em.compile()
+            em.build_graph()
             em.logger.info("looks ok")
 
         except Exception as e:

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -34,9 +34,7 @@ def main(argv=None):
     :param argv:
     :return:
     """
-    if argv is None:
-        argv = sys.argv
-    
+    ### Prepare and initialize the parser with defaults.
     description = """Efficient data transformer: converts tablular data from files
         or database connections into JSON, XML, and other text-based formats via
         instructions from a YAML configuration file. Supports joins, unions,
@@ -96,12 +94,18 @@ def main(argv=None):
         type=str,
         help='produces a JSON output file with structured information about run results'
     )
-    
-    _defaults = { "selector":"*", "params": "", "results_file": "" }
-    parser.set_defaults(**_defaults)
 
+    # Set empty defaults in case they've not been populated by the user.
+    parser.set_defaults(**{
+        "selector": "*",
+        "params": "",
+        "results_file": "",
+    })
+
+    ### Parse the user-inputs and run Earthmover, depending on the command and subcommand passed.
     args, remaining_argv = parser.parse_known_args()
-    
+
+    # Command: Version
     if args.version:
         em_dir = os.path.dirname(os.path.abspath(__file__))
         version_file = os.path.join(em_dir, 'VERSION.txt')
@@ -110,6 +114,7 @@ def main(argv=None):
             print(f"earthmover, version {VERSION}")
         exit(0)
 
+    # Command: Test
     if args.test:
         tests_dir = os.path.join( os.path.realpath(os.path.dirname(__file__)), "tests" )
         
@@ -125,6 +130,7 @@ def main(argv=None):
         em.logger.info('tests passed successfully.')
         exit(0)
 
+    ### Otherwise, initialize Earthmover for a main run.
     if not args.config_file:
         for file in DEFAULT_CONFIG_FILES:
             test_file = os.path.join(".", file)
@@ -158,45 +164,54 @@ def main(argv=None):
             cli_state_configs=cli_state_configs,
             results_file=args.results_file
         )
+
     except Exception as err:
         logger.exception(err, exc_info=True)
         raise  # Avoids linting error
 
+    # Subcommand: deps (parse Earthmover YAML and compile listed packages)
     if args.command == 'deps':
         em.logger.info(f"installing packages...")
+        if args.selector != '*':
+            em.logger.info("selector is ignored for package install.")
+
         try:
-            if args.selector != '*':
-                em.logger.info("selector is ignored for package install.")
             em.deps()
             em.logger.info("done!")
         except Exception as e:
             logger.exception(e, exc_info=em.state_configs['show_stacktrace'])
             raise
 
+    # Subcommand: compile (parse Earthmover YAML and build graph)
     elif args.command == 'compile':
         em.logger.info(f"compiling project...")
-        try:
-            if args.selector != '*':
-                em.logger.info("selector is ignored for compile-only run.")
+        if args.selector != '*':
+            em.logger.info("selector is ignored for compile-only run.")
 
+        try:
             em.merge_packages()
             em.build_graph()
             em.compile()
             em.logger.info("looks ok")
+
         except Exception as e:
             logger.exception(e, exc_info=em.state_configs['show_stacktrace'])
             raise
 
+    # Subcommand: run (compile + execute)
+    # This is the default if none is specified.
     elif args.command == 'run' or not args.command:
         if not args.command:
             em.logger.warning("[no command specified; proceeding with `run` but we recommend explicitly giving a command]")
+
         try:
             em.logger.info("starting...")
             em.merge_packages()
             em.generate(selector=args.selector)
             em.logger.info("done!")
-        except Exception as e:
-            logger.exception(e, exc_info=em.state_configs['show_stacktrace'])
+
+        except Exception as err:
+            logger.exception(err, exc_info=em.state_configs['show_stacktrace'])
             raise
 
     else:

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -189,9 +189,7 @@ def main(argv=None):
             em.logger.info("selector is ignored for compile-only run.")
 
         try:
-            em.merge_packages()
             em.compile()
-            em.build_graph()
             em.logger.info("looks ok")
 
         except Exception as e:
@@ -206,7 +204,6 @@ def main(argv=None):
 
         try:
             em.logger.info("starting...")
-            em.merge_packages()
             em.generate(selector=args.selector)
             em.logger.info("done!")
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -197,6 +197,7 @@ class Earthmover:
         for name, config in node_configs.items():
             node = node_class(name, config, earthmover=self)
             node.compile()
+            compiled_nodes.append(node)
 
             # Add the node and any source edges to the graph.
             self.graph.add_node(node.full_name, data=node)
@@ -206,8 +207,6 @@ class Earthmover:
                     node.set_upstream_source(source, self.graph.ref(source))
                 except KeyError:
                     self.error_handler.throw(f"invalid source {source}")
-
-                compiled_nodes.append(node)
 
         return compiled_nodes
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -129,7 +129,7 @@ class Earthmover:
         return configs
 
 
-    def compile(self, selector: str = "*"):
+    def compile(self):
         """
         Parse optional packages, iterate the node configs, compile each Node, and build the graph.
         Save the Nodes to their `Earthmover.{node_type}` objects.
@@ -165,25 +165,6 @@ class Earthmover:
             _cycle = nx.find_cycle(self.graph)
             self.error_handler.throw(f"the graph is not a DAG! it has the cycle {_cycle}")
 
-        # Filter on the selector if specified.
-        if selector != "*":
-            self.logger.info(f"filtering dataflow graph using selector `{selector}`")
-            self.graph = self.graph.select_subgraph(selector)
-
-        # Delete all nodes not connected to a destination.
-        while True:  # Iterate until no nodes are removed.
-            terminal_nodes = self.graph.get_terminal_nodes()
-            for node_name in terminal_nodes:
-                node = self.graph.ref(node_name)
-                if node.type != 'destination':
-                    self.graph.remove_node(node_name)
-                    self.logger.warning(
-                        f"{node.type} node `{node.name}` will not be generated because it is not connected to a destination"
-                    )
-            # Iterate until no nodes are removed.
-            if set(terminal_nodes) == set(self.graph.get_terminal_nodes()):
-                break
-
         # Draw the graph, regardless of whether a run is completed.
         if self.state_configs['show_graph']:
             self.graph.draw()
@@ -212,18 +193,45 @@ class Earthmover:
 
 
     ### Earthmover Run Methods
-    def execute(self):
+    def filter_graph_on_selector(self, graph: Graph, selector: str) -> Graph:
+        """
+        Filter a graph on an optional selector, and remove disconnected nodes.
+        """
+
+        active_graph = graph.copy()
+
+        if selector != "*":
+            self.logger.info(f"filtering dataflow graph using selector `{selector}`")
+            active_graph = active_graph.select_subgraph(selector)
+
+        # Delete all nodes not connected to a destination.
+        while True:  # Iterate until no nodes are removed.
+            terminal_nodes = active_graph.get_terminal_nodes()
+            for node_name in terminal_nodes:
+                node = active_graph.ref(node_name)
+                if node.type != 'destination':
+                    active_graph.remove_node(node_name)
+                    self.logger.warning(
+                        f"{node.type} node `{node.name}` will not be run because it is not connected to a destination"
+                    )
+            # Iterate until no nodes are removed.
+            if set(terminal_nodes) == set(active_graph.get_terminal_nodes()):
+                break
+
+        return active_graph
+
+    def execute(self, graph: Graph):
         """
         Iterate subgraphs in `Earthmover.graph` and execute each Node in order.
         :return:
         """
-        for idx, component in enumerate(nx.weakly_connected_components(self.graph)):
+        for idx, component in enumerate(nx.weakly_connected_components(graph)):
             self.logger.debug(f"processing component {idx}")
 
             # Load subgraphs (in topological sort order).
-            subgraph = self.graph.subgraph(component)
+            subgraph = graph.subgraph(component)
             for node_name in itertools.chain(*nx.topological_generations(subgraph)):
-                node = self.graph.ref(node_name)
+                node = graph.ref(node_name)
 
                 # Execute only if not already processed.
                 if node.data:
@@ -237,7 +245,7 @@ class Earthmover:
                     self.metadata["row_counts"].update({node_name: len(node.data)})
 
 
-    def hash_graph_to_runs_file(self) -> RunsFile:
+    def hash_graph_to_runs_file(self, graph: Graph) -> RunsFile:
         """
 
         :return:
@@ -269,7 +277,7 @@ class Earthmover:
 
                 # Find the latest run that matched our selector(s)...
                 most_recent_run = runs_file.get_newest_compatible_run(
-                    active_nodes=self.graph.get_node_data()
+                    active_nodes=graph.get_node_data()
                 )
 
                 if most_recent_run is None:
@@ -299,14 +307,15 @@ class Earthmover:
         return runs_file
 
 
-    def generate(self, selector: str):
+    def generate(self, selector: str = "*"):
         """
         Build DAG from YAML configs
 
         Order of operations:
-        1. Compile: compile nodes and build the graph
-        2. Execute: iterate subgraphs and build Dask execution graph
-        3. Optional Miscellaneous: add row to runs file, redraw graph with counts, and write results file
+        1. Compile: compile nodes and build the full graph
+        2. Filter to active graph on optional selector
+        3. Execute: iterate subgraphs and build Dask execution graph
+        4. Optional Miscellaneous: add row to runs file, redraw graph with counts, and write results file
 
         Build subgraph to process based on the selector. We always run through from sources to destinations
         (so all ancestors and descendants of selected nodes are also selected) but here we allow processing
@@ -317,19 +326,22 @@ class Earthmover:
         :param selector:
         :return:
         """
-        ### Compile and execute all Nodes in Dask.
-        # Compile the YAML file and build a subgraph based on the selector.
-        self.compile(selector)
+        ### Compile and execute selected Nodes in Dask.
+        # Compile the YAML file and build the full graph.
+        self.compile()
 
-        ### Hashing requires an entire class mixin and multiple additional steps.
-        runs_file = self.hash_graph_to_runs_file()
+        # Filter the graph to only selected nodes.
+        active_graph = self.filter_graph_on_selector(self.graph, selector=selector)
+
+        # Hashing requires an entire class mixin and multiple additional steps.
+        runs_file = self.hash_graph_to_runs_file(active_graph)
 
         # Unchanged runs are avoided unless the user forces the run.
         if not self.do_generate:
             exit(99) # Operation canceled
 
         # Iterate the graph and execute each Node.
-        self.execute()
+        self.execute(active_graph)
 
         ### Save run log only after a successful run! (in case of errors)
         # Note: `runs_file` is only defined in certain circumstances.
@@ -340,7 +352,7 @@ class Earthmover:
             if selector == "*":
                 destinations = "*"
             else:
-                destinations = "|".join(self.graph.get_node_data().keys())
+                destinations = "|".join(active_graph.get_node_data().keys())
 
             runs_file.write_row(selector=destinations)
 
@@ -351,14 +363,14 @@ class Earthmover:
 
             # Compute all row number values at once for performance, then update the nodes.
             computed_node_rows = dask.compute(
-                {node_name: node.num_rows for node_name, node in self.graph.get_node_data().items()}
+                {node_name: node.num_rows for node_name, node in active_graph.get_node_data().items()}
             )[0]
 
             for node_name, num_rows in computed_node_rows.items():
-                node = self.graph.ref(node_name)
+                node = active_graph.ref(node_name)
                 node.num_rows = num_rows
 
-            self.graph.draw()
+            active_graph.draw()
         
         ### Create structured output results_file if necessary
         if self.results_file:

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -177,7 +177,6 @@ class Earthmover:
 
         for name, config in node_configs.items():
             node = node_class(name, config, earthmover=self)
-            node.compile()
             compiled_nodes.append(node)
 
             # Add the node and any source edges to the graph.

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -142,7 +142,7 @@ class Earthmover:
 
         ### Optionally merge packages to update user-configs and write the composed YAML to disk.
         self.user_configs = self.merge_packages() or self.user_configs
-        self.user_configs.to_disk("./earthmover_composed.yml")
+        self.user_configs.to_disk("./earthmover_compiled.yaml")
 
         ### Compile the nodes and add to the graph type-by-type.
         self.sources = self.compile_node_configs(
@@ -197,7 +197,6 @@ class Earthmover:
         """
         Filter a graph on an optional selector, and remove disconnected nodes.
         """
-
         active_graph = graph.copy()
 
         if selector != "*":
@@ -427,13 +426,13 @@ class Earthmover:
 
         # Check that at least one package is defined
         if all(False for _ in self.package_graph.successors('root')):
-            self.error_handler.throw("No packages have been defined!")
+            self.logger.warning("No packages have been defined!")
 
         # Install each package (and any nested sub-packages) into the packages directory
         self.build_package_graph(root_node='root', package_subgraph=self.package_graph, packages_dir=self.packages_dir, install=True)
 
 
-    def merge_packages(self) -> 'YamlMapping':
+    def merge_packages(self) -> Optional['YamlMapping']:
         """
         Traverses the packages graph, merging yaml config from successors into predecessors.
         Saves the final result as the instance user_configs.

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -111,6 +111,7 @@ class Earthmover:
         self.graph: Graph = None
 
 
+    ### Template-Parsing Methods
     def load_project_configs(self, filepath: str):
         """
         Load the project config file and update global attributes.
@@ -202,6 +203,7 @@ class Earthmover:
             self.graph.draw()
 
 
+    ### Earthmover Run Methods
     def execute(self):
         """
         Iterate subgraphs in `Earthmover.graph` and execute each Node in order.
@@ -366,8 +368,8 @@ class Earthmover:
     def test(self, tests_dir: str):
         # delete files in tests/output/
         output_dir = os.path.join(tests_dir, "outputs")
-        for f in os.listdir(output_dir):
-            os.remove(os.path.join(output_dir, f))
+        for fp in os.listdir(output_dir):
+            os.remove(os.path.join(output_dir, fp))
 
         # run earthmover!
         self.generate(selector="*")
@@ -378,13 +380,13 @@ class Earthmover:
             # load expected and outputted content as dataframes, and sort them
             # because dask may shuffle output order
             _expected_file  = os.path.join(tests_dir, 'expected', filename)
-            with open(_expected_file, "r", encoding='utf-8') as f:
-                _expected_df = pd.DataFrame([l.strip() for l in f.readlines()])
+            with open(_expected_file, "r", encoding='utf-8') as fp:
+                _expected_df = pd.DataFrame([l.strip() for l in fp.readlines()])
                 _expected_df = _expected_df.sort_values(by=_expected_df.columns.tolist()).reset_index(drop=True)
 
             _outputted_file = os.path.join(tests_dir, 'outputs', filename)
-            with open(_outputted_file, "r", encoding='utf-8') as f:
-                _outputted_df = pd.DataFrame([l.strip() for l in f.readlines()])
+            with open(_outputted_file, "r", encoding='utf-8') as fp:
+                _outputted_df = pd.DataFrame([l.strip() for l in fp.readlines()])
                 _outputted_df = _outputted_df.sort_values(by=_outputted_df.columns.tolist()).reset_index(drop=True)
             
             # compare sorted contents
@@ -393,6 +395,7 @@ class Earthmover:
                 exit(1)
 
 
+    ### Packaging Methods
     def deps(self):
         """
         Installs all packages specified in the config file and any nested packages.
@@ -455,14 +458,12 @@ class Earthmover:
         package_graph.add_node('root', package=root_package)
 
         package_config = self.error_handler.assert_get_key(configs, 'packages', dtype=dict, required=False, default={})
-
         for name, config in package_config.items():
             package = Package(name, config, earthmover=self)
             package_graph.add_node(name, package=package)
             package_graph.add_edge(root_package.name, name)
 
         return package_graph
-            
 
     def build_package_graph(self, root_node: str, package_subgraph: Graph, packages_dir: str, install: bool):
         """

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -188,7 +188,7 @@ class Earthmover:
         if self.state_configs['show_graph']:
             self.graph.draw()
 
-    def compile_node_configs(self, node_configs: 'YamlMapping', node_class: 'Node'):
+    def compile_node_configs(self, node_configs: 'YamlMapping', node_class: 'Node') -> List['Node']:
         """
         Helper method to keep code DRY, yet flexible to new node types.
         """
@@ -237,7 +237,7 @@ class Earthmover:
                     self.metadata["row_counts"].update({node_name: len(node.data)})
 
 
-    def hash_graph_to_runs_file(self):
+    def hash_graph_to_runs_file(self) -> RunsFile:
         """
 
         :return:

--- a/earthmover/error_handler.py
+++ b/earthmover/error_handler.py
@@ -62,7 +62,7 @@ class ErrorContext:
             log += f"`{self.file}` "
 
         if self.node:
-            log += f"in `${self.node.type}s.{self.node.name}` "
+            log += f"in `{self.node.full_name}` "
 
         if self.operation:
             log += f"operation `{self.operation.type}` "

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -42,19 +42,9 @@ class FileDestination(Destination):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.file: str = None
-        self.template: str = None
-        self.jinja_template: jinja2.Template = None
-        self.header: str = None
-        self.footer: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.template = self.error_handler.assert_get_key(self.config, 'template', dtype=str)
+        self.header = self.config.get("header")
+        self.footer = self.config.get("footer")
 
         #config->extension is optional: if not present, we assume the destination name has an extension
         extension = ""
@@ -81,12 +71,6 @@ class FileDestination(Destination):
         if self.config.get('linearize', True):
             template_string = self.EXP.sub(" ", template_string)  # Replace multiple spaces with a single space.
 
-        if 'header' in self.config:
-            self.header = self.config["header"]
-
-        if 'footer' in self.config:
-            self.footer = self.config["footer"]
-
         #
         try:
             self.jinja_template = util.build_jinja_template(template_string, macros=self.earthmover.macros)
@@ -99,7 +83,7 @@ class FileDestination(Destination):
 
     def execute(self, **kwargs):
         """
-        There is a bug in Dask where where `dd.to_csv(mode='a', single_file=True)` fails.
+        There is a bug in Dask where `dd.to_csv(mode='a', single_file=True)` fails.
         This is resolved in 2023.8.1: https://docs.dask.org/en/stable/changelog.html#id7 
 
         :return:

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -80,7 +80,6 @@ class Node:
         self.debug = self.debug or self.config.get('debug', False)
         self.expectations = self.error_handler.assert_get_key(self.config, 'expect', dtype=list, required=False)
 
-        pass
 
     @abc.abstractmethod
     def execute(self, **kwargs):

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -57,6 +57,10 @@ class Node:
         self.progress_bar: ProgressBar = ProgressBar(minimum=10, dt=5.0)  # Always instantiate, but only use if `show_progress is True`.
         self.head_was_displayed: bool = False  # Workaround to prevent displaying the head twice when debugging.
 
+    @property
+    def full_name(self):
+        return f"${self.type}s.{self.name}"
+
     @abc.abstractmethod
     def compile(self):
         """

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -61,6 +61,12 @@ class Node:
     def full_name(self):
         return f"${self.type}s.{self.name}"
 
+    def set_upstream_source(self, source_name: str, node: 'Node'):
+        """ Upstream sources initialize as strings and are replaced during Earthmover.build_graph(). """
+        if source_name not in self.upstream_sources:
+            self.error_handler.throw(f"Source {source_name} not found in Node sources list.")
+        self.upstream_sources[source_name] = node
+
     @abc.abstractmethod
     def compile(self):
         """

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -29,6 +29,7 @@ class Node:
     def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
         self.name: str = name
         self.config: 'YamlMapping' = config
+        self.full_name: str = f"${self.type}s.{self.name}"
 
         self.earthmover: 'Earthmover' = earthmover
         self.logger: 'Logger' = earthmover.logger
@@ -56,16 +57,6 @@ class Node:
         self.show_progress: bool = self.config.get('show_progress', self.earthmover.state_configs["show_progress"])
         self.progress_bar: ProgressBar = ProgressBar(minimum=10, dt=5.0)  # Always instantiate, but only use if `show_progress is True`.
         self.head_was_displayed: bool = False  # Workaround to prevent displaying the head twice when debugging.
-
-    @property
-    def full_name(self):
-        return f"${self.type}s.{self.name}"
-
-    def set_upstream_source(self, source_name: str, node: 'Node'):
-        """ Upstream sources initialize as strings and are replaced during Earthmover.build_graph(). """
-        if source_name not in self.upstream_sources:
-            self.error_handler.throw(f"Source {source_name} not found in Node sources list.")
-        self.upstream_sources[source_name] = node
 
     @abc.abstractmethod
     def compile(self):
@@ -195,3 +186,9 @@ class Node:
         if self.partition_size:
             data = data.repartition(partition_size=self.partition_size)
         return data
+
+    def set_upstream_source(self, source_name: str, node: 'Node'):
+        """ Upstream sources initialize as strings and are replaced during Earthmover.build_graph(). """
+        if source_name not in self.upstream_sources:
+            self.error_handler.throw(f"Source {source_name} not found in Node sources list.")
+        self.upstream_sources[source_name] = node

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -52,7 +52,7 @@ class Source(Node):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.chunksize: int = None
+        self.chunksize: int = self.error_handler.assert_get_key(self.config, 'chunksize', dtype=int, required=False, default=self.NUM_ROWS_PER_CHUNK)
 
         # A source can be blank if `optional=True` is specified in its configs.
         # (In this case, `columns` must be specified, and are used to construct an empty
@@ -61,14 +61,6 @@ class Source(Node):
 
         # Optional fields can be defined to be added as null columns if not present in the DataFrame.
         self.optional_fields: List[str] = self.config.get('optional_fields', [])
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
-        self.chunksize = self.error_handler.assert_get_key(self.config, 'chunksize', dtype=int, required=False, default=self.NUM_ROWS_PER_CHUNK)
 
     def post_execute(self, **kwargs):
         """
@@ -108,17 +100,6 @@ class FileSource(Source):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.file: str = None
-        self.file_type: str = None
-        self.read_lambda: Callable = None
-        self.columns_list: List[str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.file = self.error_handler.assert_get_key(self.config, 'file', dtype=str, required=False)
 
         #
@@ -301,16 +282,6 @@ class FtpSource(Source):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.connection: str = None
-        self.ftp: ftplib.FTP = None
-        self.file: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.connection = self.error_handler.assert_get_key(self.config, 'connection', dtype=str)
 
         # There's probably a network builtin to simplify this.
@@ -373,15 +344,6 @@ class SqlSource(Source):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.connection: str = None
-        self.query: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.connection = self.error_handler.assert_get_key(self.config, 'connection', dtype=str)
         self.query = self.error_handler.assert_get_key(self.config, 'query', dtype=str)
 

--- a/earthmover/nodes/transformation.py
+++ b/earthmover/nodes/transformation.py
@@ -30,16 +30,6 @@ class Transformation(Node):
                 for source in operation.sources:
                     self.upstream_sources[source] = None
 
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
-
-        for operation in self.operations:
-            operation.compile()
-
         # Force error-handler reset before graph is built.
         self.error_handler.ctx.update(
             file=self.config.__file__, line=self.config.__line__, node=self, operation=None

--- a/earthmover/nodes/transformation.py
+++ b/earthmover/nodes/transformation.py
@@ -25,6 +25,7 @@ class Transformation(Node):
             operation = Operation(self.name, operation_config, earthmover=self.earthmover)
             self.operations.append(operation)
 
+            # Only used by DataFrame Operations. Consider moving into those inits.
             if hasattr(operation, 'sources'):
                 for source in operation.sources:
                     self.upstream_sources[source] = None
@@ -38,6 +39,11 @@ class Transformation(Node):
 
         for operation in self.operations:
             operation.compile()
+
+        # Force error-handler reset before graph is built.
+        self.error_handler.ctx.update(
+            file=self.config.__file__, line=self.config.__line__, node=self, operation=None
+        )
 
     def execute(self):
         """

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -24,14 +24,6 @@ class AddColumnsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_dict: Dict[str, str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.columns_dict = self.error_handler.assert_get_key(self.config, 'columns', dtype=dict)
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
@@ -80,14 +72,6 @@ class ModifyColumnsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_dict: Dict[str, str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.columns_dict = self.error_handler.assert_get_key(self.config, 'columns', dtype=dict)
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
@@ -141,14 +125,6 @@ class DuplicateColumnsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_dict: Dict[str, str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.columns_dict = self.error_handler.assert_get_key(self.config, 'columns', dtype=dict)
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
@@ -186,14 +162,6 @@ class RenameColumnsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_dict: Dict[str, str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.columns_dict = self.error_handler.assert_get_key(self.config, 'columns', dtype=dict)
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
@@ -229,14 +197,6 @@ class DropColumnsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_to_drop: List[str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.columns_to_drop = self.error_handler.assert_get_key(self.config, 'columns', dtype=list)
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
@@ -268,15 +228,6 @@ class KeepColumnsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.header: List[str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
-
         self.header = self.error_handler.assert_get_key(self.config, 'columns', dtype=list)
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
@@ -308,20 +259,8 @@ class CombineColumnsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_list: List[str] = None
-        self.new_column: str = None
-        self.separator: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
-
         self.columns_list = self.error_handler.assert_get_key(self.config, 'columns', dtype=list)
         self.new_column   = self.error_handler.assert_get_key(self.config, 'new_column', dtype=str)
-
         self.separator = self.config.get('separator', "")
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
@@ -358,16 +297,6 @@ class MapValuesOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_list: List[str] = None
-        self.map_file: str = None
-        self.mapping: Dict[str, str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
 
         # Only 'column' or 'columns' can be populated
         _column  = self.error_handler.assert_get_key(self.config, 'column', dtype=str, required=False)
@@ -451,19 +380,6 @@ class DateFormatOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_list: List[str] = None
-        self.from_format: str = None
-        self.to_format: str = None
-        self.ignore_errors: bool = None
-        self.exact_match: bool = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
-
         self.from_format = self.error_handler.assert_get_key(self.config, 'from_format', dtype=str)
         self.to_format   = self.error_handler.assert_get_key(self.config, 'to_format', dtype=str)
         self.ignore_errors   = self.error_handler.assert_get_key(self.config, 'ignore_errors', dtype=bool, required=False)

--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -31,25 +31,6 @@ class JoinOperation(Operation):
         # Check joined node
         self.sources: List[str] = self.error_handler.assert_get_key(self.config, 'sources', dtype=list)
 
-        self.join_type: str = None
-
-        self.left_keys: List[str] = None
-        self.left_keep_cols: List[str] = None
-        self.left_drop_cols: List[str] = None
-        self.left_cols: List[str] = None  # The final column list built of cols and keys
-
-        self.right_keys: List[str] = None
-        self.right_keep_cols: List[str] = None
-        self.right_drop_cols: List[str] = None
-        self.right_cols: List[str] = None  # The final column list built of cols and keys
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
-
         # Check left keys
         _key  = self.error_handler.assert_get_key(self.config, 'left_key', dtype=str, required=False)
         _keys = self.error_handler.assert_get_key(self.config, 'left_keys', dtype=list, required=False)
@@ -97,16 +78,16 @@ class JoinOperation(Operation):
         super().execute(data, data_mapping=data_mapping, **kwargs)
 
         # Build left dataset
-        self.left_cols = data.columns
+        left_cols = data.columns
 
         if self.left_keep_cols:
-            if not set(self.left_keep_cols).issubset(self.left_cols):
+            if not set(self.left_keep_cols).issubset(left_cols):
                 self.error_handler.throw(
                     "columns in `left_keep_columns` are not defined in the dataset"
                 )
                 raise
 
-            self.left_cols = list(set(self.left_keep_cols).union(self.left_keys))
+            left_cols = list(set(self.left_keep_cols).union(self.left_keys))
 
         elif self.left_drop_cols:
             if any(col in self.left_keys for col in self.left_drop_cols):
@@ -115,23 +96,23 @@ class JoinOperation(Operation):
                 )
                 raise
 
-            self.left_cols = list(set(self.left_cols).difference(self.left_drop_cols))
+            left_cols = list(set(left_cols).difference(self.left_drop_cols))
 
-        left_data = data[self.left_cols]
+        left_data = data[left_cols]
 
         # Iterate each right dataset
         for source in self.sources:
             right_data = data_mapping[source].data
-            self.right_cols = right_data.columns
+            right_cols = right_data.columns
 
             if self.right_keep_cols:
-                if not set(self.right_keep_cols).issubset(self.right_cols):
+                if not set(self.right_keep_cols).issubset(right_cols):
                     self.error_handler.throw(
                         "columns in `right_keep_columns` are not defined in the dataset"
                     )
                     raise
 
-                self.right_cols = list(set(self.right_keep_cols).union(self.right_keys))
+                right_cols = list(set(self.right_keep_cols).union(self.right_keys))
 
             elif self.right_drop_cols:
                 if any(col in self.right_keys for col in self.right_drop_cols):
@@ -140,9 +121,9 @@ class JoinOperation(Operation):
                     )
                     raise
 
-                self.right_cols = list(set(self.right_cols).difference(self.right_drop_cols))
+                right_cols = list(set(right_cols).difference(self.right_drop_cols))
 
-            right_data = right_data[self.right_cols]
+            right_data = right_data[right_cols]
 
             # Complete the merge, using different logic depending on the partitions of the datasets.
             try:

--- a/earthmover/operations/groupby.py
+++ b/earthmover/operations/groupby.py
@@ -22,15 +22,6 @@ class GroupByWithCountOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.group_by_columns: List[str] = None
-        self.count_column: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.group_by_columns = self.error_handler.assert_get_key(self.config, 'group_by_columns', dtype=list)
         self.count_column     = self.error_handler.assert_get_key(self.config, 'count_column', dtype=str)
 
@@ -81,16 +72,6 @@ class GroupByWithAggOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.group_by_columns: List[str] = None
-        self.agg_column: str = None
-        self.separator: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.group_by_columns = self.error_handler.assert_get_key(self.config, 'group_by_columns', dtype=list)
         self.agg_column       = self.error_handler.assert_get_key(self.config, 'agg_column', dtype=str)
 
@@ -142,15 +123,6 @@ class GroupByWithRankOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.group_by_columns: str = None
-        self.rank_column: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.group_by_columns = self.error_handler.assert_get_key(self.config, 'group_by_columns', dtype=list)
         self.rank_column = self.error_handler.assert_get_key(self.config, 'rank_column', dtype=str)
 
@@ -195,15 +167,6 @@ class GroupByOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.group_by_columns: List[str] = None
-        self.create_columns_dict: Dict[str, str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
         self.group_by_columns    = self.error_handler.assert_get_key(self.config, 'group_by_columns', dtype=list)
         self.create_columns_dict = self.error_handler.assert_get_key(self.config, 'create_columns', dtype=dict)
 

--- a/earthmover/operations/row.py
+++ b/earthmover/operations/row.py
@@ -19,14 +19,6 @@ class DistinctRowsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.columns_list: List[str] = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
 
         # Only 'column' or 'columns' can be populated
         _column  = self.error_handler.assert_get_key(self.config, 'column', dtype=str, required=False)
@@ -71,16 +63,6 @@ class FilterRowsOperation(Operation):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.query: str = None
-        self.behavior: str = None
-
-    def compile(self):
-        """
-
-        :return:
-        """
-        super().compile()
-
         self.query    = self.error_handler.assert_get_key(self.config, 'query', dtype=str)
         self.behavior = self.error_handler.assert_get_key(self.config, 'behavior', dtype=str)
 
@@ -125,16 +107,6 @@ class SortRowsOperation(Operation):
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.columns_list: List[str] = None
-            self.descending: bool = None
-
-        def compile(self):
-            """
-
-            :return:
-            """
-            super().compile()
-
             self.columns_list = self.error_handler.assert_get_key(self.config, 'columns', dtype=list)
             self.descending = self.error_handler.assert_get_key(self.config, 'descending', required=False, default=False)
 


### PR DESCRIPTION
Changes from RC/0.3.0
- Add comments and clean up __main__.py
- Add `Node.full_name` and `Node.set_upstream_source()`
- Add `Earthmover.load_project_configs()` that automatically updates `Earthmover.params` and `Earthmover.macros` during configs processing (DRY)
- Make `user_configs`, `project_graph`, and `graph` lazy objects that are initialized during `Earthmover.compile()` or `Earthmover.deps()`
- Move "earthmover_composed.yaml" write to `Earthmover.compile()`
- Unify `Earthmover.compile()` with `Earthmover.build_graph()`
- Refactor `Earthmover.compile_node_configs()` to its own helper class
  - Simplify initialization of `Earthmover.{sources, transformations, destinations}` using `Earthmover.compile_node_configs()`
- Update `Earthmover.merge_packages()` to optionally return refactored `user_configs` YamlMapping
  - TODO: How to retrieve parent YamlMapping if only a root node?
- Make `Earthmover.build_root_package_graph()` a (nearly) static method with YamlMapping input and Graph output
- Add `Earthmover.filter_graph_on_selector()` as a (nearly) static method returning a Graph output
- Minor bugfix: reset error_handler context after Transformation compile() to show more accurate line numbers during Transformation error-logging