### PR TITLE
Hotfix/optional parquet sources

### DIFF
--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -144,15 +144,6 @@ class FileSource(Source):
         if "://" in self.file:
             self.is_remote = True
 
-        elif self.file and not self.optional:
-            try:
-                self.size = os.path.getsize(self.file)
-            except FileNotFoundError:
-                self.error_handler.throw(
-                    f"Source file {self.file} not found"
-                )
-                raise
-
     def execute(self):
         """
 

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -160,7 +160,7 @@ class FileSource(Source):
                 self.data = pd.DataFrame(columns=self.columns_list, dtype="string")
             else:
                 self.data = self.read_lambda(self.file, self.config)
-                if not self.remote:
+                if not self.is_remote:
                     self.size = os.path.getsize(self.file)
 
             # Verify the column list provided matches the number of columns in the dataframe.

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -307,7 +307,16 @@ class FtpSource(Source):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.connection = self.error_handler.assert_get_key(self.config, 'connection', dtype=str)
+        self.ftp = None  # FTP connection is made during execute.
 
+    def execute(self):
+        """
+        ftp://user:pass@host:port/path/to/file.ext
+        :return:
+        """
+        super().execute()
+
+        ### Parse the connection string and attempt connection to FTP.
         # There's probably a network builtin to simplify this.
         user, passwd, host, port, self.file = re.match(
             r"ftp://(.*?):?(.*?)@?([^:/]*):?(.*?)/(.*)",
@@ -328,13 +337,6 @@ class FtpSource(Source):
             self.error_handler.throw(
                 f"source file {self.connection} could not be accessed: {err}"
             )
-
-    def execute(self):
-        """
-        ftp://user:pass@host:port/path/to/file.ext
-        :return:
-        """
-        super().execute()
 
         try:
             # TODO: Can Dask read from FTP directly without this workaround?

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -156,7 +156,7 @@ class FileSource(Source):
 
         try:
             # Build an empty dataframe if the path is not populated or if an empty directory is passed (for Parquet files).
-            if self.optional and not self.file or (os.path.isdir(self.file) and not os.path.listdir(self.file)):
+            if self.optional and not self.file or (os.path.isdir(self.file) and not os.listdir(self.file)):
                 self.data = pd.DataFrame(columns=self.columns_list, dtype="string")
             else:
                 self.data = self.read_lambda(self.file, self.config)

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -164,7 +164,8 @@ class FileSource(Source):
         self._verify_packages(self.file_type)
 
         try:
-            if not self.file and self.optional:
+            # Build an empty dataframe if the path is not populated or if an empty directory is passed (for Parquet files).
+            if self.optional and not self.file or (os.path.isdir(self.file) and not os.path.listdir(self.file)):
                 self.data = pd.DataFrame(columns=self.columns_list, dtype="string")
             else:
                 self.data = self.read_lambda(self.file, self.config)

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -160,6 +160,8 @@ class FileSource(Source):
                 self.data = pd.DataFrame(columns=self.columns_list, dtype="string")
             else:
                 self.data = self.read_lambda(self.file, self.config)
+                if not self.remote:
+                    self.size = os.path.getsize(self.file)
 
             # Verify the column list provided matches the number of columns in the dataframe.
             if self.columns_list:


### PR DESCRIPTION
* internal: Move FileSource size-checking and FtpSource FTP-connecting from compile to execute.
* internal: Allow filepaths to be passed to optional FileSources, and check for file before creating empty dataframe
* internal: Build an empty dataframe if an empty folder is passed to an optional FileSource