### PR TITLE
Only write `earthmover_compiled.yaml` on compile, not run

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ Some details of the design of this tool are discussed below.
 
 Note that due to step (3) above, *runtime* Jinja expressions (such as column definitions for `add_columns` or `modify_columns` operations) should be wrapped with `{%raw%}...{%endraw%}` to avoid being parsed when the YAML is being loaded.
 
-The parsed YAML is written to a file called `earthmover_compiled.yaml` in your working directory during a `compile` or `run` command. This file can be used to debug issues related to compile-time Jinja or [project composition](#project-composition).
+The parsed YAML is written to a file called `earthmover_compiled.yaml` in your working directory during a `compile` command. This file can be used to debug issues related to compile-time Jinja or [project composition](#project-composition).
 
 
 ## DAG

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -189,7 +189,7 @@ def main(argv=None):
             em.logger.info("selector is ignored for compile-only run.")
 
         try:
-            em.compile()
+            em.compile(to_disk=True)
             em.logger.info("looks ok")
 
         except Exception as e:

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -128,7 +128,7 @@ class Earthmover:
         return configs
 
 
-    def compile(self):
+    def compile(self, to_disk: bool = False):
         """
         Parse optional packages, iterate the node configs, compile each Node, and build the graph.
         Save the Nodes to their `Earthmover.{node_type}` objects.
@@ -141,7 +141,8 @@ class Earthmover:
 
         ### Optionally merge packages to update user-configs and write the composed YAML to disk.
         self.user_configs = self.merge_packages() or self.user_configs
-        self.user_configs.to_disk("./earthmover_compiled.yaml")
+        if to_disk:
+            self.user_configs.to_disk("./earthmover_compiled.yaml")
 
         ### Compile the nodes and add to the graph type-by-type.
         self.sources = self.compile_node_configs(


### PR DESCRIPTION
Adds an argument to `earthmover.compile()` to specify whether a `earthmover_compiled.yaml` will be written to disk. Defaults to false, set to true for `earthmover compile` commands.