### PR TITLE
Git clone timeout when running `earthmover deps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ config:
   parameter_defaults:
     SOURCE_DIR: ./sources/
   show_progress: True
+  git_auth_timeout: 120
 
 ```
 * (optional) `output_dir` determines where generated JSONL is stored. The default is `./`.
@@ -148,7 +149,7 @@ config:
 * (optional) Specify Jinja `macros` which will be available within any Jinja template content throughout the project. (This can slow performance.)
 * (optional) Specify `parameter_defaults` which will be used if the user fails to specify a particular [parameter](#command-line-parameters) or [environment variable](#environment-variable-references).
 * (optional) Specify whether to `show_progress` while processing, via a Dask progress bar.
-
+* (optional) Specify length of time (in seconds) to wait for the user to enter Git credentials if needed during package installation; default is 60. See [project composition](#project-composition) for more details on package installation.
 
 ### **`definitions`**
 The `definitions` section of the [YAML configuration](#yaml-configuration) is an optional section you can use to define configurations which are reused throughout the rest of the configuration. `earthmover` does nothing special with this section, it's just interpreted by the YAML parser. However, this can be a very useful way to keep your YAML configuration [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) &ndash; rather than redefine the same values, Jinja phrases, etc. throughout your config, define them once in this section and refer to them later using [YAML anchors, aliases, and overrides](https://www.linode.com/docs/guides/yaml-anchors-aliases-overrides-extensions/).

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ config:
 * (optional) Specify Jinja `macros` which will be available within any Jinja template content throughout the project. (This can slow performance.)
 * (optional) Specify `parameter_defaults` which will be used if the user fails to specify a particular [parameter](#command-line-parameters) or [environment variable](#environment-variable-references).
 * (optional) Specify whether to `show_progress` while processing, via a Dask progress bar.
-* (optional) Specify length of time (in seconds) to wait for the user to enter Git credentials if needed during package installation; default is 60. See [project composition](#project-composition) for more details on package installation.
+* (optional) Specify the `git_auth_timeout` (in seconds) to wait for the user to enter Git credentials if needed during package installation; default is 60. See [project composition](#project-composition) for more details on package installation.
 
 ### **`definitions`**
 The `definitions` section of the [YAML configuration](#yaml-configuration) is an optional section you can use to define configurations which are reused throughout the rest of the configuration. `earthmover` does nothing special with this section, it's just interpreted by the YAML parser. However, this can be a very useful way to keep your YAML configuration [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) &ndash; rather than redefine the same values, Jinja phrases, etc. throughout your config, define them once in this section and refer to them later using [YAML anchors, aliases, and overrides](https://www.linode.com/docs/guides/yaml-anchors-aliases-overrides-extensions/).

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -517,7 +517,7 @@ class Earthmover:
             # Install packages if necessary, or retrieve path to package yaml file
             package_node = self.package_graph.nodes[package_name]
             if install:
-                installed_package_yaml = package_node['package'].install(packages_dir)
+                installed_package_yaml = package_node['package'].install(packages_dir, self.state_configs.get('git_auth_timeout', 60))
             else:
                 package_node['package'].package_path = os.path.join(packages_dir, package_name)
                 installed_package_yaml = package_node['package'].get_installed_config_file()

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -38,6 +38,7 @@ class Earthmover:
         "show_stacktrace": False,
         "tmp_dir": tempfile.gettempdir(),
         "show_progress": False,
+        "git_auth_timeout": 60
     }
 
     sources: List[Source] = []
@@ -517,7 +518,7 @@ class Earthmover:
             # Install packages if necessary, or retrieve path to package yaml file
             package_node = self.package_graph.nodes[package_name]
             if install:
-                installed_package_yaml = package_node['package'].install(packages_dir, self.state_configs.get('git_auth_timeout', 60))
+                installed_package_yaml = package_node['package'].install(packages_dir, git_auth_timeout=self.state_configs['git_auth_timeout'])
             else:
                 package_node['package'].package_path = os.path.join(packages_dir, package_name)
                 installed_package_yaml = package_node['package'].get_installed_config_file()

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -190,6 +190,7 @@ class GitHubPackage(Package):
 
         # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:
+            os.rmdir(self.package_path)
             self.error_handler.throw(
                 f"Git clone command timed out for the {self.name} package ({source_path}). Are git credentials correctly configured?"
             )

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -1,6 +1,7 @@
 import git
 import os
 import shutil
+import subprocess
 from typing import Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from earthmover.earthmover import Earthmover
@@ -182,16 +183,16 @@ class GitHubPackage(Package):
         os.mkdir(tmp_package_path)
 
         if branch:
-            repo = git.Repo.clone_from(source_path, tmp_package_path, branch=branch)
+            subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=10)
         else:  #If branch is not specified, default working branch is used
-            repo = git.Repo.clone_from(source_path, tmp_package_path)
+            subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=10)
 
         if subdirectory: # Avoids the package being nested in folders
-            subdirectory_path = os.path.join(repo.working_tree_dir, subdirectory)
+            subdirectory_path = os.path.join(tmp_package_path, subdirectory)
             shutil.copytree(subdirectory_path, self.package_path)
         else:
-            shutil.copytree(repo.working_tree_dir, self.package_path)
+            shutil.copytree(tmp_package_path, self.package_path)
 
-        git.rmtree(repo.working_tree_dir)
+        git.rmtree(tmp_package_path)
 
         return super().get_installed_config_file()

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -180,7 +180,7 @@ class GitHubPackage(Package):
         branch = self.error_handler.assert_get_key(self.config, 'branch', dtype=str, required=False, default=None)
 
         tmp_package_path = os.path.join(packages_dir, 'tmp_git')
-        os.mkdir(tmp_package_path)
+        os.makedirs(tmp_package_path)
 
         try:
             if branch:
@@ -190,7 +190,6 @@ class GitHubPackage(Package):
 
         # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:
-            os.rmdir(tmp_package_path)
             self.error_handler.throw(
                 f"Git clone command timed out for the {self.name} package ({source_path}). Are git credentials correctly configured?"
             )

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -180,7 +180,7 @@ class GitHubPackage(Package):
         branch = self.error_handler.assert_get_key(self.config, 'branch', dtype=str, required=False, default=None)
 
         tmp_package_path = os.path.join(packages_dir, 'tmp_git')
-        os.makedirs(tmp_package_path)
+        os.makedirs(tmp_package_path, exist_ok=True)
 
         try:
             if branch:

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -184,12 +184,15 @@ class GitHubPackage(Package):
 
         try:
             if branch:
-                subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=10)
+                subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=60)
             else:  #If branch is not specified, default working branch is used
-                subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=10)
+                subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=60)
+
+        # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:
+            os.rmdir(tmp_package_path)
             self.error_handler.throw(
-                f"Git clone command timed out for the {self.name} package. Are git credentials correctly configured?"
+                f"Git clone command timed out for the {self.name} package ({source_path}). Are git credentials correctly configured?"
             )
             raise
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -190,7 +190,7 @@ class GitHubPackage(Package):
 
         # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:
-            os.rmdir(self.tmp_package_path)
+            os.rmdir(tmp_package_path)
             self.error_handler.throw(
                 f"Git clone command timed out for the {self.name} package ({source_path}). Are git credentials correctly configured?"
             )

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -137,7 +137,7 @@ class LocalPackage(Package):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def install(self, packages_dir):
+    def install(self, packages_dir, *args):
         """
         Makes a copy of a local package directory into <project>/packages.
         :return:
@@ -166,7 +166,7 @@ class GitHubPackage(Package):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def install(self, packages_dir):
+    def install(self, packages_dir, git_auth_timeout):
         """
         Clones a GitHub repository into <project>/packages.
         If a subdirectory is specified, clone the repository into a temporary folder and copy the desired subdirectory into <project>/packages.
@@ -183,9 +183,9 @@ class GitHubPackage(Package):
 
         try:
             if branch:
-                subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=60)
+                subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=git_auth_timeout)
             else:  #If branch is not specified, default working branch is used
-                subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=60)
+                subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=git_auth_timeout)
 
         # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -137,7 +137,7 @@ class LocalPackage(Package):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def install(self, packages_dir, *args):
+    def install(self, packages_dir, **kwargs):
         """
         Makes a copy of a local package directory into <project>/packages.
         :return:
@@ -183,9 +183,11 @@ class GitHubPackage(Package):
 
         try:
             if branch:
-                subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=git_auth_timeout)
+                command = ["git", "clone", "-b", branch, source_path, "."]
             else:  #If branch is not specified, default working branch is used
-                subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=git_auth_timeout)
+                command = ["git", "clone", source_path, "."]
+
+            subprocess.run(command, cwd=tmp_package_path, timeout=git_auth_timeout)
 
         # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -190,7 +190,7 @@ class GitHubPackage(Package):
 
         # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:
-            os.rmdir(tmp_package_path)
+            shutil.rmtree(tmp_package_path)
             self.error_handler.throw(
                 f"Git clone command timed out for the {self.name} package ({source_path}). Are git credentials correctly configured?"
             )

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -15,7 +15,7 @@ class Package:
     """
     mode: str = None
 
-    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None):
+    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
         """
         Logic for assigning packages to their respective classes.
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -15,7 +15,7 @@ class Package:
     """
     mode: str = None
 
-    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
+    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None):
         """
         Logic for assigning packages to their respective classes.
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -182,10 +182,16 @@ class GitHubPackage(Package):
         tmp_package_path = os.path.join(packages_dir, 'tmp_git')
         os.mkdir(tmp_package_path)
 
-        if branch:
-            subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=10)
-        else:  #If branch is not specified, default working branch is used
-            subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=10)
+        try:
+            if branch:
+                subprocess.run(["git", "clone", "-b", branch, source_path, "."], cwd=tmp_package_path, timeout=10)
+            else:  #If branch is not specified, default working branch is used
+                subprocess.run(["git", "clone", source_path, "."], cwd=tmp_package_path, timeout=10)
+        except subprocess.TimeoutExpired:
+            self.error_handler.throw(
+                f"Git clone command timed out for the {self.name} package. Are git credentials correctly configured?"
+            )
+            raise
 
         if subdirectory: # Avoids the package being nested in folders
             subdirectory_path = os.path.join(tmp_package_path, subdirectory)

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -1,6 +1,6 @@
-import git
 import os
 import shutil
+import stat
 import subprocess
 from typing import Optional, TYPE_CHECKING
 if TYPE_CHECKING:
@@ -190,7 +190,7 @@ class GitHubPackage(Package):
 
         # Timeouts are implemented to prevent automated runs from hanging if the git clone command is prompting for credentials
         except subprocess.TimeoutExpired:
-            os.rmdir(self.package_path)
+            os.rmdir(self.tmp_package_path)
             self.error_handler.throw(
                 f"Git clone command timed out for the {self.name} package ({source_path}). Are git credentials correctly configured?"
             )
@@ -202,6 +202,6 @@ class GitHubPackage(Package):
         else:
             shutil.copytree(tmp_package_path, self.package_path)
 
-        git.rmtree(tmp_package_path)
+        shutil.rmtree(tmp_package_path)
 
         return super().get_installed_config_file()

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import stat
 import subprocess
 from typing import Optional, TYPE_CHECKING
 if TYPE_CHECKING:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 wheel
 aiohttp>=3.8.1
 dask[dataframe]~=2023.5.0
-GitPython>=3.1.40
 Jinja2>=2.11.3
 networkx>=2.6.3
 pandas>=1.3.5


### PR DESCRIPTION
This PR fixes an issue with `earthmover deps` hanging indefinitely as it attempts to clone a private repo and waits for a user without stored credentials to enter a username and password. The git clone command will timeout after the time specified by the optional `git_auth_timeout` config. Default is 60 seconds, long enough to still allow a human user to enter a username and password during local development.

In making this change I was able to remove the GitPython dependency, as the `git clone` command is now handled by `subprocess`.

I tested this locally to ensure unchanged behavior when credentials are stored and I ran it in a docker container without git credentials to test the timeout. 

