### PR TITLE
Feature/union all columns

### DIFF
--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -146,13 +146,13 @@ class UnionOperation(Operation):
 
     """
     allowed_configs: Tuple[str] = (
-        'operation', 'repartition', 'sources', 'fill_missing_columns',
+        'operation', 'repartition', 'sources', 'fill_missing',
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.sources = self.error_handler.assert_get_key(self.config, 'sources', dtype=list)
-        self.fill_missing_columns = self.error_handler.assert_get_key(self.config, 'fill_missing_columns', dtype=bool, required=False, default=False)
+        self.fill_missing = self.error_handler.assert_get_key(self.config, 'fill_missing', dtype=bool, required=False, default=False)
 
     def execute(self, data: 'DataFrame', data_mapping: Dict[str, Node], **kwargs) -> 'DataFrame':
         """
@@ -165,7 +165,7 @@ class UnionOperation(Operation):
             source_data = data_mapping[source].data
 
             if set(source_data.columns) != set(data.columns):
-                if self.fill_missing_columns:
+                if self.fill_missing:
                     self.logger.debug('Dataframes to union do not share identical columns. Added columns will be filled with nulls.')
                 else:
                     self.error_handler.throw('dataframes to union do not share identical columns')

--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -146,13 +146,13 @@ class UnionOperation(Operation):
 
     """
     allowed_configs: Tuple[str] = (
-        'operation', 'repartition', 'sources', 'fill_missing',
+        'operation', 'repartition', 'sources', 'fill_missing_columns',
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.sources = self.error_handler.assert_get_key(self.config, 'sources', dtype=list)
-        self.fill_missing = self.error_handler.assert_get_key(self.config, 'fill_missing', dtype=bool, required=False, default=False)
+        self.fill_missing_columns = self.error_handler.assert_get_key(self.config, 'fill_missing_columns', dtype=bool, required=False, default=False)
 
     def execute(self, data: 'DataFrame', data_mapping: Dict[str, Node], **kwargs) -> 'DataFrame':
         """
@@ -165,7 +165,7 @@ class UnionOperation(Operation):
             source_data = data_mapping[source].data
 
             if set(source_data.columns) != set(data.columns):
-                if self.fill_missing:
+                if self.fill_missing_columns:
                     self.logger.debug('Dataframes to union do not share identical columns. Added columns will be filled with nulls.')
                 else:
                     self.error_handler.throw('dataframes to union do not share identical columns')

--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -166,7 +166,7 @@ class UnionOperation(Operation):
 
             if set(source_data.columns) != set(data.columns):
                 if self.fill_missing:
-                    self.logger.debug('Dataframes to union do not share identical columns. Added columns will be filled with nulls.')
+                    self.logger.debug('Dataframes to union do not share identical columns. Missing columns will be filled with nulls.')
                 else:
                     self.error_handler.throw('dataframes to union do not share identical columns')
                     raise


### PR DESCRIPTION
Add optional 'fill_missing_columns' field to UnionOperation that does not raise an error message when specified sources are not identical in schema. New columns will be filled with nulls.

TODO: Is there is a better name to use for this field? Let's have a chat before we commit!