### PR TITLE
Fix read_json with nested JSON

### DIFF
--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -1,3 +1,4 @@
+import dask.config as dask_config
 import dask.dataframe as dd
 import ftplib
 import io
@@ -158,6 +159,7 @@ class FileSource(Source):
             if self.optional and not os.path.exists(self.file) or (os.path.isdir(self.file) and not os.listdir(self.file)):
                 self.data = pd.DataFrame(columns=self.columns_list, dtype="string")
             else:
+                dask_config.set({'dataframe.convert-string': False})
                 self.data = self.read_lambda(self.file, self.config)
                 if not self.is_remote:
                     self.size = os.path.getsize(self.file)


### PR DESCRIPTION
This simple PR fixes a bug [introduced](https://github.com/edanalytics/earthmover/blob/rc/0.3.2/earthmover/nodes/destination.py#L121) in earthmover 0.3.0 where nested JSON would be loaded as a stringified Python dictionary, which is difficult to use in downstream Jinja.

Example: a JSONL file like
```jsonl
{"key1":"value1", "key2":{"key2a":"value2a", "key2b":"value2b"}}
{"key1":"value3", "key2":{"key2a":"value4a", "key2b":"value4b"}}
```
would result in a dataframe like

| key1 | key2 |
| --- | --- |
| "value1" | "{'key2a': 'value2a', 'key2b': 'value2b'}" |
| "value1" | "{'key2a': 'value2a', 'key2b': 'value2b'}" |

(key2 is a string representation of a Python dictionary) instead of

| key1 | key2 |
| --- | --- |
| "value1" | {'key2a': 'value2a', 'key2b': 'value2b'} |
| "value1" | {'key2a': 'value2a', 'key2b': 'value2b'} |

(key2 is a Python object).

Thanks to @AngelicaLastra for pointing out this bug.