### PR TITLE
Fix escape chars in output when `linearize: False`

### DIFF
--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -3,7 +3,6 @@ import jinja2
 import os
 import pandas as pd
 import re
-import dask
 
 from earthmover.nodes.node import Node
 from earthmover import util

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -3,6 +3,7 @@ import jinja2
 import os
 import pandas as pd
 import re
+import dask
 
 from earthmover.nodes.node import Node
 from earthmover import util
@@ -103,19 +104,22 @@ class FileDestination(Destination):
         # Verify the output directory exists.
         os.makedirs(os.path.dirname(self.file), exist_ok=True)
 
-        # Write the optional header, the JSON lines as CSV (for performance), and the optional footer.
-        self.data.to_csv(
-            filename=self.file, single_file=True, mode='wt', index=False,
-            header=[self.header] if self.header else False,  # We must write the header directly due to aforementioned bug.
-            escapechar="\x01", sep="\x02", quoting=csv.QUOTE_NONE,  # Pretend to be CSV to improve performance
-        )
+        # Write the optional header, each line, and the optional footer.
+        with open(self.file, 'w+', encoding='utf-8') as fp:
+            if self.header:
+                fp.write(self.header)
 
-        if self.footer:
-            with open(self.file, 'a', encoding='utf-8') as fp:
+            self.data.apply(self.write_row, meta=pd.Series('str'), fp=fp).compute()
+
+            if self.footer:
                 fp.write(self.footer)
 
         self.logger.debug(f"output `{self.file}` written")
         self.size = os.path.getsize(self.file)
+
+    def write_row(self, row: pd.Series, fp):
+        fp.write(row + "\n")
+        return "" # this wipes out data in the dataframe after it's written, which should save some memory
 
     def render_row(self, row: pd.Series):
         row = row.astype("string").fillna('')

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -83,9 +83,7 @@ class FileDestination(Destination):
 
     def execute(self, **kwargs):
         """
-        There is a bug in Dask where `dd.to_csv(mode='a', single_file=True)` fails.
-        This is resolved in 2023.8.1: https://docs.dask.org/en/stable/changelog.html#id7 
-
+        
         :return:
         """
         super().execute(**kwargs)
@@ -118,7 +116,7 @@ class FileDestination(Destination):
 
     def write_row(self, row: pd.Series, fp):
         fp.write(row + "\n")
-        return "" # this wipes out data in the dataframe after it's written, which should save some memory
+        return None # this wipes out data in the dataframe after it's written, which should save some memory
 
     def render_row(self, row: pd.Series):
         row = row.astype("string").fillna('')


### PR DESCRIPTION
This PR fixes a bug introduced in earthmover 0.2.0. Writing out destination files [was done](https://github.com/edanalytics/earthmover/blob/6094c1ba0e21253c85a9a7c15913764acf7bc14e/earthmover/nodes/destination.py#L107-L111) with `Dask.to_csv()` and some "invisible" escape characters, however when a destination declared `linearize: False` (which prevents stripping out newline characters from each rendered Jinja template) these "invisible" characters were present in the output file.

Now, like we `render_row()` to render a Jinja template for each row of a dataframe, we similarly `write_row()` to append the rendered row to an open file handle.

I tested performance by loading a 31MB, 1M-row, 3-column CSV file and immediately writing it to a destination with the following template:
```json-jinja
{
    {% for key, value in __row_data__.items() -%}
    "{{key}}": "{{value|trim}}"{% if not loop.last %},{% endif %}
    {% endfor %}
}
```
Results:
* old `.to_csv()` method with `linearize: True` took 636s
* old `.to_csv()` method with `linearize: False` took 456s
* new `map_partitions()` method with `linearize: True` took 441s
* new `map_partitions()` method with `linearize: False` took 431s

So the new method at least as fast as `.to_csv()`. I also checked the output file for malformed lines (in case different Dask processes writing to the same file conflicted somehow) but it looked fine.