### PR TITLE
Fix `__row_data__` in `add_columns` and `modify_columns` operations

### DIFF
--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -80,8 +80,9 @@ def render_jinja_template(row: 'Series', template: jinja2.Template, template_str
     :return:
     """
     try:
-        row["__row_data__"] = row.to_dict()
-        return template.render(row)
+        row_data = row.to_dict()
+        row_data.update({"__row_data__": row.to_dict()})
+        return template.render(row_data)
 
     except Exception as err:
         error_handler.ctx.remove('line')

--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -80,6 +80,7 @@ def render_jinja_template(row: 'Series', template: jinja2.Template, template_str
     :return:
     """
     try:
+        row["__row_data__"] = row.to_dict()
         return template.render(row)
 
     except Exception as err:


### PR DESCRIPTION
The [earthmover documentation](https://github.com/edanalytics/earthmover/#transformations) states that you can use `{{__row_data__['col_name']}}` in the Jinja expressions of an `add_columns` or `modify_columns` operation, but that's currently not true - that variable is only available in the context when rendering a Jinja template of a destination. This PR fixes this bug.

Separately, the documentation also states that you can use `{{__row_number__}}` in your Jinja expressions, but that's not actually implemented anywhere in earthmover, and implementing it is non-trivial given the Dask backend. Perhaps in the short-term this should be removed from the documentation while we figure out the best way to implement it.