### PR TITLE
add support for Jinja in a destination node header and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ destinations:
     header: <html><body><h1>Course List:</h1>
     footer: </body></html>
 ```
-For each file you want materialized, provide the `source` and the `template` file &mdash; a text file (JSON, XML, HTML, etc.) containing Jinja with references to the columns of `source`. The materialized file will contain `template` rendered for each row of `source`, with an optional `header` prefix and `footer` postfix. Files are materialized using your specified `extension` (which is required).
+For each file you want materialized, provide the `source` and the `template` file &mdash; a text file (JSON, XML, HTML, etc.) containing Jinja with references to the columns of `source`. The materialized file will contain `template` rendered for each row of `source`, with an optional `header` prefix and `footer` postfix (both of which may contain Jinja, and which may reference `__row_data__` which is the first row of the data frame... a formulation such as `{%raw%}{% for k in __row_data__.pop('__row_data__').keys() %}{{k}}{% if not loop.last %},{% endif %}{% endfor %}{%endraw%}` may be useful). Files are materialized using your specified `extension` (which is required).
 
 If `linearize` is `True`, all line breaks are removed from the template, resulting in one output line per row. (This is useful for creating JSONL and other linear output formats.) If omitted, `linearize` is `True`.
 

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 import re
+import warnings
 
 from earthmover.nodes.node import Node
 from earthmover import util
@@ -126,8 +127,10 @@ class FileDestination(Destination):
                 (self.header and util.contains_jinja(self.header))
                 or (self.footer and util.contains_jinja(self.footer))
             ):
-                # (use `npartitions=-1` because the first N partitions could be empty)
-                first_row = self.upstream_sources[self.source].data.head(1, npartitions=-1).reset_index(drop=True).iloc[0]
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", message="Insufficient elements for `head`")
+                    # (use `npartitions=-1` because the first N partitions could be empty)
+                    first_row = self.upstream_sources[self.source].data.head(1, npartitions=-1).reset_index(drop=True).iloc[0]
                 
             if self.header and util.contains_jinja(self.header):
                 jinja_template = util.build_jinja_template(self.header, macros=self.earthmover.macros)


### PR DESCRIPTION
This PR adds support for a destination node's `header` and `footer` to contain Jinja. The first row of data is passed in, so `__row_data__.pop('__row_data__').keys()` contains the column names, which can be used to define a dynamic header/footer. For example:
```yaml
destinations:
  input_no_student_id_match:
    source: $transformations.input_no_student_id_match
    template: ./verbatim.csvt
    header: |
      {%raw%}{% for k in __row_data__.pop('__row_data__').keys() %}{{k}}{% if not loop.last %},{% endif %}{% endfor %}{%endraw%}

    extension: csv
    linearize: True
```