### PR TITLE
add support for a `require_rows` boolean or non-negative int on any node

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,13 +719,11 @@ If `linearize` is `True`, all line breaks are removed from the template, resulti
 
 ## Global options
 
-Any source, transformation, or destination may also specify `debug: True` which will output the dataframe shape and columns after the node completes processing. This can be very useful while building and debugging.
-
-Additionally, the `show_progress` boolean flag can be specified on any source, transformation, or destination to display a progress bar while processing.
-
-Finally, `repartition` can be passed to any node to repartition the node in memory before continuing to the next node.
-Set either the number of bytes, or a text representation (e.g., "100MB") to shuffle data into new partitions of that size.
-(Note: this configuration is advanced, and its use may drastically affect performance.)
+Any source, transformation, or destination node may also specify
+* `debug: True`, which outputs the dataframe shape and columns after the node completes processing (this can be helpful for building and debugging)
+* `require_rows: True` or `require_rows: 10` to have earthmover exit with an error if 0 (for `True`) or less then 10 (for `10`) rows are present in the dataframe after the node completes processing
+* `show_progress: True` to display a progress bar while processing this node
+* `repartition: True` to repartition the node in memory before continuing to the next node; set either the number of bytes, or a text representation (e.g., "100MB") to shuffle data into new partitions of that size (Note: this configuration is advanced, and its use may drastically affect performance)
 
 # Usage
 Once you have the required [setup](#setup) and your source data, run the transformations with

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -14,7 +14,7 @@ class Destination(Node):
     """
     type: str = 'destination'
     mode: str = None  # Documents which class was chosen.
-    allowed_configs: Tuple[str] = ('debug', 'expect', 'show_progress', 'repartition', 'source',)
+    allowed_configs: Tuple[str] = ('debug', 'expect', 'require_rows', 'show_progress', 'repartition', 'source',)
 
     NULL_REPR: object = None  # Representation for Nones, NaNs, and NAs on output.
     STRING_DTYPES: Tuple[object] = ()  # Datatypes to be forced to strings on output (default none).

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -6,7 +6,6 @@ import pandas as pd
 import warnings
 
 from dask.diagnostics import ProgressBar
-from dask.graph_manipulation import bind
 
 from earthmover import util
 

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -122,7 +122,6 @@ class Node:
 
         # Only actually compute() and count the rows if `require_rows` was defined for this node.
         if self.require_rows > 0:
-            self.num_rows = dask.compute(self.num_rows)[0]
             self.check_require_rows(self.require_rows)
 
         # Display row-count and dataframe shape if debug is enabled.
@@ -132,6 +131,7 @@ class Node:
         pass
 
     def check_require_rows(self, num_required_rows):
+        self.num_rows = dask.compute(self.num_rows)[0]
         if self.num_rows < num_required_rows:
             self.error_handler.throw(
                 f"Source `{self.full_name}` failed require_rows >= {num_required_rows}` (only {self.num_rows} rows found)"

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -24,7 +24,7 @@ class Node:
 
     """
     type: str = None
-    allowed_configs: Tuple[str] = ('debug', 'expect', 'show_progress', 'repartition','require_rows')
+    allowed_configs: Tuple[str] = ('debug', 'expect', 'require_rows', 'show_progress', 'repartition')
 
     def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
         self.name: str = name

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -6,6 +6,7 @@ import pandas as pd
 import warnings
 
 from dask.diagnostics import ProgressBar
+from dask.graph_manipulation import bind
 
 from earthmover import util
 
@@ -24,7 +25,7 @@ class Node:
 
     """
     type: str = None
-    allowed_configs: Tuple[str] = ('debug', 'expect', 'show_progress', 'repartition',)
+    allowed_configs: Tuple[str] = ('debug', 'expect', 'show_progress', 'repartition','require_rows')
 
     def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
         self.name: str = name
@@ -48,6 +49,7 @@ class Node:
         self.num_cols: int = None
 
         self.expectations: List[str] = None
+        self.require_rows: bool = False
         self.debug: bool = (self.logger.level <= logging.DEBUG)  # Default to Logger's level.
 
         # Internal Dask configs
@@ -69,6 +71,11 @@ class Node:
         # Always check for debug and expectations
         self.debug = self.debug or self.config.get('debug', False)
         self.expectations = self.error_handler.assert_get_key(self.config, 'expect', dtype=list, required=False)
+        self.require_rows = int(self.require_rows or self.config.get('require_rows', False))
+        if self.require_rows < 0:
+            self.error_handler.throw(
+                f"Source `{self.full_name}` require_rows cannot be negative"
+            )
 
 
     @abc.abstractmethod
@@ -114,11 +121,26 @@ class Node:
         else:
             self.num_rows, self.num_cols = self.data.shape
 
+        # Only actually compute() and count the rows if `require_rows` was defined for this node.
+        if self.require_rows > 0:
+            self.num_rows = dask.compute(self.num_rows)[0]
+            self.check_require_rows(self.require_rows)
+
         # Display row-count and dataframe shape if debug is enabled.
         if self.debug:
             self.display_head()
 
         pass
+
+    def check_require_rows(self, num_required_rows):
+        if self.num_rows < num_required_rows:
+            self.error_handler.throw(
+                f"Source `{self.full_name}` failed require_rows >= {num_required_rows}` (only {self.num_rows} rows found)"
+            )
+        else:
+            self.logger.info(
+                f"Assertion passed! {self.name}: require_rows >= {num_required_rows}"
+            )
 
     def display_head(self, nrows: int = 5):
         """

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -24,7 +24,7 @@ class Source(Node):
     type: str = 'source'
     mode: str = None  # Documents which class was chosen.
     is_remote: bool = None
-    allowed_configs: Tuple[str] = ('debug', 'expect', 'show_progress', 'repartition', 'chunksize', 'optional', 'optional_fields',)
+    allowed_configs: Tuple[str] = ('debug', 'expect', 'require_rows', 'show_progress', 'repartition', 'chunksize', 'optional', 'optional_fields',)
 
     NUM_ROWS_PER_CHUNK: int = 1000000
 

--- a/earthmover/nodes/transformation.py
+++ b/earthmover/nodes/transformation.py
@@ -9,7 +9,7 @@ class Transformation(Node):
 
     """
     type: str = 'transformation'
-    allowed_configs: Tuple[str] = ('debug', 'expect', 'show_progress', 'repartition', 'operations', 'source',)
+    allowed_configs: Tuple[str] = ('debug', 'expect', 'require_rows', 'show_progress', 'repartition', 'operations', 'source',)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Any node (source, transformation, destination) can now declare `require_rows: True` or `require_rows: 10` to provide a way to ensure zero-row nodes stop earthmover execution.