### PR TITLE
implementing a limit_rows operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ Limit the number of rows in the dataframe.
         count: 5 # required, no default
         offset: 10 # optional, default 0
 ```
+(If fewer than `count` rows in in the dataframe, they will all be returned.)
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ Limit the number of rows in the dataframe.
         count: 5 # required, no default
         offset: 10 # optional, default 0
 ```
-(If fewer than `count` rows in in the dataframe, they will all be returned.)
+(If fewer than `count` rows in the dataframe, they will all be returned.)
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -574,6 +574,18 @@ By default, rows are sorted ascendingly. Set `descending: True` to reverse this 
 
 
 <details>
+<summary><code>limit_rows</code></summary>
+
+Limit the number of rows in the dataframe.
+```yaml
+      - operation: limit_rows
+        count: 5 # required, no default
+        offset: 10 # optional, default 0
+```
+</details>
+
+
+<details>
 <summary><code>flatten</code></summary>
 
 Split values in a column and create a copy of the row for each value.

--- a/earthmover/operations/operation.py
+++ b/earthmover/operations/operation.py
@@ -46,6 +46,7 @@ class Operation(Node):
             'distinct_rows': row_operations.DistinctRowsOperation,
             'filter_rows': row_operations.FilterRowsOperation,
             'sort_rows': row_operations.SortRowsOperation,
+            'limit_rows': row_operations.LimitRowsOperation,
             'flatten': row_operations.FlattenOperation,
 
             'group_by_with_rank': groupby_operations.GroupByWithRankOperation,

--- a/earthmover/operations/row.py
+++ b/earthmover/operations/row.py
@@ -1,5 +1,6 @@
 from earthmover.operations.operation import Operation
 
+import warnings
 from typing import Tuple
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -149,8 +150,10 @@ class LimitRowsOperation(Operation):
                     "count for a limit operation must be a positive integer"
                 )
                 raise
-
-            return data.head(self.count + self.offset, npartitions=-1, compute=False).tail(self.count, compute=False)
+            
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message="Insufficient elements for `head`")
+                return data.head(self.count + self.offset, npartitions=-1, compute=False).tail(self.count, compute=False)
 
 
 class FlattenOperation(Operation):

--- a/earthmover/operations/row.py
+++ b/earthmover/operations/row.py
@@ -123,6 +123,35 @@ class SortRowsOperation(Operation):
 
             return data.sort_values(by=self.columns_list, ascending=(not self.descending))
 
+class LimitRowsOperation(Operation):
+        """
+
+        """
+        allowed_configs: Tuple[str] = (
+            'operation', 'count',
+            'offset',
+        )
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.count = self.error_handler.assert_get_key(self.config, 'count', dtype=int, required=True)
+            self.offset = self.error_handler.assert_get_key(self.config, 'offset', dtype=int, required=False, default=0)
+
+        def execute(self, data: 'DataFrame', **kwargs):
+            """
+
+            :return:
+            """
+            super().execute(data, **kwargs)
+
+            if self.count < 1:
+                self.error_handler.throw(
+                    "count for a limit operation must be a positive integer"
+                )
+                raise
+
+            return data.head(self.count + self.offset, compute=False).tail(self.count, compute=False)
+
 
 class FlattenOperation(Operation):
     """

--- a/earthmover/operations/row.py
+++ b/earthmover/operations/row.py
@@ -150,7 +150,7 @@ class LimitRowsOperation(Operation):
                 )
                 raise
 
-            return data.head(self.count + self.offset, compute=False).tail(self.count, compute=False)
+            return data.head(self.count + self.offset, npartitions=-1, compute=False).tail(self.count, compute=False)
 
 
 class FlattenOperation(Operation):

--- a/earthmover/tests/earthmover.yaml
+++ b/earthmover/tests/earthmover.yaml
@@ -243,6 +243,8 @@ transformations:
           - species
         new_column: scientific_name
         separator: " "
+      - operation: limit_rows
+        count: 10 # this should do nothing, since there are only 4 big cats in the dataset
 
   total_of_each_species:
     source: $transformations.joined_inventories


### PR DESCRIPTION
This PR implements a `limit_rows` operation. For example:
```yaml
      - operation: limit_rows
        count: 5 # required, no default
        offset: 10 # optional, default 0
```