### PR TITLE
Bugfix: union fails with duplicate columns

### DIFF
--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -171,6 +171,12 @@ class UnionOperation(Operation):
                     self.error_handler.throw('dataframes to union do not share identical columns')
                     raise
 
+            # Raise an error if duplicate columns are found in either data source.
+            # These can cause `AttributeError: 'DataFrame' object has no attribute 'dtype'` because a DataFrame is returned during union instead of a column.
+            if len(source_data.columns) != len(set(source_data.columns)) or len(data.columns) != len(set(data.columns)):
+                self.error_handler.throw("One or more columns in either dataframe are duplicated. Union cannot be performed consistently.")
+                raise
+
             try:
                 data = dd.concat([data, source_data], ignore_index=True)
             


### PR DESCRIPTION
This PR resolves a bug in Earthmover where if a dataframe with multiple identically-named columns is passed into the union operation, the following stacktrace appears:
```
Traceback (most recent call last):
  File "/home/jalvord/.venv/earthbeam__sc_test/src/earthmover/earthmover/operations/dataframe.py", line 175, in execute
    data = dd.concat([data, source_data], ignore_index=True)
  File "/home/jalvord/.venv/earthbeam__sc_test/lib/python3.8/site-packages/dask/dataframe/multi.py", line 1327, in concat
    return stack_partitions(
  File "/home/jalvord/.venv/earthbeam__sc_test/lib/python3.8/site-packages/dask/dataframe/multi.py", line 1102, in stack_partitions
    needs_astype = [
  File "/home/jalvord/.venv/earthbeam__sc_test/lib/python3.8/site-packages/dask/dataframe/multi.py", line 1105, in <listcomp>
    if df[col].dtype != meta[col].dtype
  File "/home/jalvord/.venv/earthbeam__sc_test/lib/python3.8/site-packages/dask/dataframe/core.py", line 4905, in __getattr__
    raise AttributeError("'DataFrame' object has no attribute %r" % key)
AttributeError: 'DataFrame' object has no attribute 'dtype'
```

This bug occurs because `df[col]` returns a Series if `col` is unique and a DataFrame if `col` has duplicates. This PR raises an error in cases like these, because it does not make sense to try to union two dataframes if we don't know which columns to union.