### PR TITLE
Bugfix/remove excel source pyarrow dependency

### DIFF
--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -276,7 +276,6 @@ class FileSource(Source):
                 raise
         elif file_type == 'excel':
             try:
-                import pyarrow
                 import openpyxl
             except ImportError:
                 self.error_handler.throw(


### PR DESCRIPTION
The `sources._verify_packages` function throws an error for Excel sources if `pyarrow` is not installed, but `pyarrow` isn't needed to load Excel files and is not installed by `pip install earthmover[excel]`. 