### PR TITLE
adds a `--set` flag to the cli to enable overriding values in _compiled_ `earthmover.yml`

### DIFF
--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -99,9 +99,14 @@ def main(argv=None):
         action='store_true',
         help='overwrites `show_stacktrace` config in the config file to true; sets `log_level` to DEBUG'
     )
-    parser.add_argument("--results-file",
+    parser.add_argument("-r", "--results-file",
         type=str,
         help='produces a JSON output file with structured information about run results'
+    )
+    parser.add_argument("--set",
+        type=str,
+        nargs="*",
+        help='overrides a setting in the config YAML; example: --set config.tmp_dir /tmp'
     )
 
     # Set empty defaults in case they've not been populated by the user.
@@ -117,7 +122,7 @@ def main(argv=None):
         unknown_args_str = ', '.join(f"`{c}`" for c in unknown_args)
         print(f"unknown arguments {unknown_args_str} passed, use -h flag for help")
         exit(1)
-    
+
     if args.command is not None and args.command not in ALLOWED_COMMANDS:
         print(f"unknown command '{args.command}' passed, use -h flag for help")
         exit(1)
@@ -167,6 +172,9 @@ def main(argv=None):
     if not args.config_file:
         logger.error("config file not specified with `-c` flag, and no default {" + ", ".join(DEFAULT_CONFIG_FILES) + "} found")
 
+    if len(args.set)%2 != 0: # odd number of overrides
+        logger.error("overrides specified with --set must be followed by an even number of strings (key value key value ...)")
+
     # Update state configs with those forced via the command line.
     cli_state_configs = {}
 
@@ -188,6 +196,7 @@ def main(argv=None):
             skip_hashing=args.skip_hashing,
             cli_state_configs=cli_state_configs,
             results_file=args.results_file,
+            overrides=args.set,
         )
 
     except Exception as err:

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -172,7 +172,7 @@ def main(argv=None):
     if not args.config_file:
         logger.error("config file not specified with `-c` flag, and no default {" + ", ".join(DEFAULT_CONFIG_FILES) + "} found")
 
-    if len(args.set)%2 != 0: # odd number of overrides
+    if args.set and len(args.set)%2 != 0: # odd number of overrides
         logger.error("overrides specified with --set must be followed by an even number of strings (key value key value ...)")
 
     # Update state configs with those forced via the command line.

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -174,6 +174,9 @@ def main(argv=None):
 
     if args.set and len(args.set)%2 != 0: # odd number of overrides
         logger.error("overrides specified with --set must be followed by an even number of strings (key value key value ...)")
+    overrides = None
+    if args.set:
+        overrides = dict(zip(args.set[::2], args.set[1::2]))
 
     # Update state configs with those forced via the command line.
     cli_state_configs = {}
@@ -196,7 +199,7 @@ def main(argv=None):
             skip_hashing=args.skip_hashing,
             cli_state_configs=cli_state_configs,
             results_file=args.results_file,
-            overrides=args.set,
+            overrides=overrides,
         )
 
     except Exception as err:

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -139,11 +139,12 @@ class Earthmover:
 
     def inject_cli_overrides(self, configs, prefix=None):
         # parse self.overrides into configs:
-        for i in range(0, len(self.overrides), 2):
-            key = self.overrides[i]
-            if not prefix or key.startswith(prefix):
-                value = self.overrides[i+1]
-                configs.set_path(key.lstrip(prefix), value)
+        if self.overrides:
+            for i in range(0, len(self.overrides), 2):
+                key = self.overrides[i]
+                if not prefix or key.startswith(prefix):
+                    value = self.overrides[i+1]
+                    configs.set_path(key.lstrip(prefix), value)
         return configs
 
     def compile(self, to_disk: bool = False):

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -140,10 +140,8 @@ class Earthmover:
     def inject_cli_overrides(self, configs, prefix=None):
         # parse self.overrides into configs:
         if self.overrides:
-            for i in range(0, len(self.overrides), 2):
-                key = self.overrides[i]
+            for key, value in self.overrides.items():
                 if not prefix or key.startswith(prefix):
-                    value = self.overrides[i+1]
                     configs.set_path(key.lstrip(prefix), value)
         return configs
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -57,7 +57,7 @@ class Earthmover:
         skip_hashing: bool = False,
         cli_state_configs: Optional[dict] = None,
         results_file: str = "",
-        overrides: Optional[str] = [],
+        overrides: Optional[dict] = None,
     ):
         self.do_generate = True
         self.force = force

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -56,6 +56,7 @@ class Earthmover:
         skip_hashing: bool = False,
         cli_state_configs: Optional[dict] = None,
         results_file: str = "",
+        overrides: Optional[str] = [],
     ):
         self.do_generate = True
         self.force = force
@@ -63,6 +64,7 @@ class Earthmover:
 
         self.results_file = results_file
         self.config_file = os.path.abspath(config_file)
+        self.overrides = overrides
         self.compiled_yaml_file = COMPILED_YAML_FILE
         self.error_handler = ErrorHandler(file=self.config_file)
 
@@ -130,6 +132,13 @@ class Earthmover:
 
         return configs
 
+    def inject_cli_overrides(self, configs):
+        # parse self.overrides into configs:
+        for i in range(0, len(self.overrides), 2):
+            key = self.overrides[i]
+            value = self.overrides[i+1]
+            configs.set_path(key, value)
+        return configs
 
     def compile(self, to_disk: bool = False):
         """
@@ -146,6 +155,7 @@ class Earthmover:
         self.user_configs = self.merge_packages() or self.user_configs
         if to_disk:
             self.user_configs.to_disk(self.compiled_yaml_file)
+        self.user_configs = self.inject_cli_overrides(self.user_configs)
 
         ### Compile the nodes and add to the graph type-by-type.
         self.sources = self.compile_node_configs(

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -34,9 +34,26 @@ class YamlMapping(dict):
     def set_path(self, path, value):
         path_pieces = path.split(".")
         if len(path_pieces)==1:
-            self[path] = value
+            self[path] = self.autocast(value)
         else:
             self[path_pieces[0]].set_path(".".join(path_pieces[1:]), value)
+    
+    @staticmethod
+    def autocast(value):
+        if value.lower() in ['true', 'yes', 'on']:
+            return True
+        elif value.lower() in ['false', 'no', 'off']:
+            return False
+        elif '.' in value:
+            try:
+                return float(value)
+            except ValueError:
+                return value
+        else:
+            try:
+                return int(value)
+            except ValueError:
+                return value
     
     def to_dict(self):
         """

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -30,6 +30,14 @@ class YamlMapping(dict):
                 self[key] = val
         return self
 
+    # enables setting values inside the YamlMapping by path, e.g. `configs.set_path("config.tmp_dir", "/mypath")`
+    def set_path(self, path, value):
+        path_pieces = path.split(".")
+        if len(path_pieces)==1:
+            self[path] = value
+        else:
+            self[path_pieces[0]].set_path(".".join(path_pieces[1:]), value)
+    
     def to_dict(self):
         """
         Convert a YAML Mapping to a standard dictionary.

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -36,7 +36,7 @@ class YamlMapping(dict):
         current = self
         for path_piece in path_pieces[:-1]:
             if path_piece not in current.keys():
-                current[path_piece]  =YamlMapping()
+                current[path_piece] = YamlMapping()
             current = current[path_piece]
         current[path_pieces[-1]] = self.autocast(value)
     

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -42,9 +42,9 @@ class YamlMapping(dict):
     
     @staticmethod
     def autocast(value):
-        if value.lower() in ['true', 'yes', 'on']:
+        if value.lower() in ['true', 'yes', 'on', 't', 'y']:
             return True
-        elif value.lower() in ['false', 'no', 'off']:
+        elif value.lower() in ['false', 'no', 'off', 'f', 'n']:
             return False
         elif '.' in value:
             try:

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -33,10 +33,12 @@ class YamlMapping(dict):
     # enables setting values inside the YamlMapping by path, e.g. `configs.set_path("config.tmp_dir", "/mypath")`
     def set_path(self, path, value):
         path_pieces = path.split(".")
-        if len(path_pieces)==1:
-            self[path] = self.autocast(value)
-        else:
-            self[path_pieces[0]].set_path(".".join(path_pieces[1:]), value)
+        current = self
+        for path_piece in path_pieces[:-1]:
+            if path_piece not in current.keys():
+                current[path_piece]  =YamlMapping()
+            current = current[path_piece]
+        current[path_pieces[-1]] = self.autocast(value)
     
     @staticmethod
     def autocast(value):


### PR DESCRIPTION
This PR adds a `--set` flag to the cli to enable overriding values in _compiled_ `earthmover.yml`. For example, you can
```bash
earthmover run -c path/to/earthmover.yml --set config.tmp_dir /tmp/earthmover
```
or
```bash
earthmover run -c path/to/earthmover.yml --set destinations.schools.extension ndjson
```
or even
```bash
earthmover run -c path/to/earthmover.yml --set sources.schools.file ./myschools.csv
```

Spaces in values are possible by enclosing the value in quotes, such as
```bash
earthmover run -c path/to/earthmover.yml --set sources.schools.file './my schools with spaces.csv'
```

Only values of "simple" types (bool, int, float, str) can be overridden... if you try something like
```bash
earthmover run -c path/to/earthmover.yml --set sources.schools.columns [district_id,school_id,school_name]
```
the resulting YAML would look like
```yaml
...
sources:
  schools:
    ...
    columns: '[district_id,school_id,school_name]'
...
```
which is invalid and so earthmover would throw an error. This limitation means that it is impossible, for example, to override anything in a transformation's `operations` (which are a list).

Note that the overrides are applied to the _compiled_ YAML, so something like
```bash
earthmover run -c path/to/earthmover.yml --set config.parameter_defaults.MY_PARAM my_value
```
will run but have no effect, because `MY_PARAM` has already been interpolated into the YAML before the override is applied.

Finally, note that this feature could deprecate
* the `-e` or `--show-stacktrace` flag, which could now instead be `--set config.show_stacktrace True`
* the `-g` or `--show-graph` flag, which could now instead be `--set config.show_graph True`

We might consider adding deprecation notices when these flags are used, and plan to remove them in a future version of earthmover.