### PR TITLE
Feature/python 312  pyarrow strings

### DIFF
--- a/earthmover/__init__.py
+++ b/earthmover/__init__.py
@@ -7,7 +7,5 @@ import dask
 dask.config.set({'dataframe.query-planning': False})
 
 # performance enhancements
-dask.config.set({"dataframe.convert-string": True})
 import pandas as pd
 pd.options.mode.copy_on_write = True
-pd.options.mode.string_storage = "pyarrow"

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -245,7 +245,7 @@ class FileSource(Source):
 
         # We don't want to activate the function inside this helper function.
         read_lambda_mapping = {
-            'csv'       : lambda file, config: dd.read_csv(file, sep=sep, dtype=str, encoding=config.get('encoding', "utf8"), keep_default_na=False, skiprows=__get_skiprows(config)),
+            'csv'       : lambda file, config: dd.read_csv(file, sep=sep, dtype="string", encoding=config.get('encoding', "utf8"), keep_default_na=False, skiprows=__get_skiprows(config)),
             'excel'     : lambda file, config: pd.read_excel(file, sheet_name=config.get("sheet", 0), keep_default_na=False),
             'feather'   : lambda file, _     : pd.read_feather(file),
             'fixedwidth': lambda file, _     : dd.read_fwf(file),
@@ -258,7 +258,7 @@ class FileSource(Source):
             'spss'      : lambda file, _     : pd.read_spss(file),
             'stata'     : lambda file, _     : pd.read_stata(file),
             'xml'       : lambda file, config: pd.read_xml(file, xpath=config.get('xpath', "./*")),
-            'tsv'       : lambda file, config: dd.read_csv(file, sep=sep, dtype=str, encoding=config.get('encoding', "utf8"), keep_default_na=False, skiprows=__get_skiprows(config)),
+            'tsv'       : lambda file, config: dd.read_csv(file, sep=sep, dtype="string", encoding=config.get('encoding', "utf8"), keep_default_na=False, skiprows=__get_skiprows(config)),
         }
         return read_lambda_mapping.get(file_type)
 

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -159,7 +159,6 @@ class FileSource(Source):
             if self.optional and not os.path.exists(self.file) or (os.path.isdir(self.file) and not os.listdir(self.file)):
                 self.data = pd.DataFrame(columns=self.columns_list, dtype="string")
             else:
-                dask_config.set({'dataframe.convert-string': False})
                 self.data = self.read_lambda(self.file, self.config)
                 if not self.is_remote:
                     self.size = os.path.getsize(self.file)

--- a/earthmover/tests/earthmover.yaml
+++ b/earthmover/tests/earthmover.yaml
@@ -280,13 +280,13 @@ transformations:
       - operation: add_columns
         columns:
           {% for month in months %}
-          avg_days_rain_{{month}}: "{%raw%}{{weather.avg_days_of_rain.{%endraw%}{{month}}{%raw%}}}{%endraw%}"
-          avg_high_temp_{{month}}: "{%raw%}{{weather.temperatures.avg_highs.{%endraw%}{{month}}{%raw%}}}{%endraw%}"
-          avg_low_temp_{{month}}: "{%raw%}{{weather.temperatures.avg_lows.{%endraw%}{{month}}{%raw%}}}{%endraw%}"
+          avg_days_rain_{{month}}: "{%raw%}{{fromjson(weather).avg_days_of_rain.{%endraw%}{{month}}{%raw%}}}{%endraw%}"
+          avg_high_temp_{{month}}: "{%raw%}{{fromjson(weather).temperatures.avg_highs.{%endraw%}{{month}}{%raw%}}}{%endraw%}"
+          avg_low_temp_{{month}}: "{%raw%}{{fromjson(weather).temperatures.avg_lows.{%endraw%}{{month}}{%raw%}}}{%endraw%}"
           {% endfor %}
-          avg_days_rain_year: "{%raw%}{{{%endraw%}{%for month in months%}weather.avg_days_of_rain.{{month}}|int{%if not loop.last%} + {%endif%}{%endfor%}{%raw%}}}{%endraw%}"
-          avg_high_temp: "{%raw%}{{(({%endraw%}{%for month in months%}weather.temperatures.avg_highs.{{month}}|int{%if not loop.last%} + {%endif%}{%endfor%}{%raw%})/12)|int}}{%endraw%}"
-          avg_low_temp: "{%raw%}{{(({%endraw%}{%for month in months%}weather.temperatures.avg_lows.{{month}}|int{%if not loop.last%} + {%endif%}{%endfor%}{%raw%})/12)|int}}{%endraw%}"
+          avg_days_rain_year: "{%raw%}{{{%endraw%}{%for month in months%}fromjson(weather).avg_days_of_rain.{{month}}|int{%if not loop.last%} + {%endif%}{%endfor%}{%raw%}}}{%endraw%}"
+          avg_high_temp: "{%raw%}{{(({%endraw%}{%for month in months%}fromjson(weather).temperatures.avg_highs.{{month}}|int{%if not loop.last%} + {%endif%}{%endfor%}{%raw%})/12)|int}}{%endraw%}"
+          avg_low_temp: "{%raw%}{{(({%endraw%}{%for month in months%}fromjson(weather).temperatures.avg_lows.{{month}}|int{%if not loop.last%} + {%endif%}{%endfor%}{%raw%})/12)|int}}{%endraw%}"
       - operation: drop_columns
         columns:
           - weather

--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -1,3 +1,4 @@
+import ast  # Used for malformed JSON
 import jinja2
 import hashlib
 import json
@@ -5,7 +6,7 @@ import os
 
 from sys import exc_info
 
-from typing import Optional
+from typing import Optional, Union
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from earthmover.error_handler import ErrorHandler
@@ -122,6 +123,14 @@ def jinja2_template_error_lineno():
             return tb.tb_lineno
         tb = tb.tb_next
 
+def fromjson(obj: Union[str, dict]) -> dict:
+    """
+    Helper method to parse malformed JSON with single quotes.
+    """
+    try:
+        return json.loads(obj)
+    except json.decoder.JSONDecodeError:
+        return ast.literal_eval(obj)
 
 def build_jinja_template(template_string: str, macros: str = ""):
     """
@@ -132,6 +141,6 @@ def build_jinja_template(template_string: str, macros: str = ""):
     ).from_string(macros.strip() + template_string)
 
     template.globals['md5'] = lambda x: hashlib.md5(x.encode('utf-8')).hexdigest()
-    template.globals['fromjson'] = lambda x: json.loads(x)
+    template.globals['fromjson'] = fromjson
 
     return template

--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -127,6 +127,9 @@ def fromjson(obj: Union[str, dict]) -> dict:
     """
     Helper method to parse malformed JSON with single quotes.
     """
+    if isinstance(obj, dict):
+        return obj
+
     try:
         return json.loads(obj)
     except json.decoder.JSONDecodeError:


### PR DESCRIPTION
This is a research branch trying to resolve the lack of PyArrow strings being used in Python 3.12. There are a few main changes:
- Force datatype in `read_csv()` from `str` (i.e., Python strings) to `"string"` (i.e., default string type).
- Remove forced string-deconversion from `FileSource.execute()`.

That second change causes breakages when using nested JSON data (since we are no longer using generic `object` datatypes. The following fixes are required:
- Overload `fromjson()` Jinja macro to use `ast.literal_eval()` when JSON has single-quotes.
- Require `fromjson()` be applied to Jinja templating in YAML when retrieving nested fields.

Some observations:
- The differences in runtime between Python 3.8 and 3.12 is drastic. Python 3.8 runs in one third the time with 2/3rds the memory during `earthmover -t`.
- We can remove the mandatory calls to the `pyarrow` backend, since this is turned on by default when available and raises an error in 3.8 otherwise.

Please let me know your thoughts. 