### PR TITLE
Bugfix: Project composition – nested local packages & resolving relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased changes
 * bugfix: `earthmover deps` failed to find nested local packages
+* bugfix: relative paths not resolved correct when using project composition
 
 ### v0.4.0
 <details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased changes
 * bugfix: `earthmover deps` failed to find nested local packages
 * bugfix: relative paths not resolved correct when using project composition
+* bugfix: bugfix: `--results-file` required a directory prefix
 
 ### v0.4.0
 <details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased changes
+* bugfix: `earthmover deps` failed to find nested local packages
+
 ### v0.4.0
 <details>
 <summary>Released 2024-10-16</summary>

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -398,14 +398,15 @@ class Earthmover:
         
         ### Create structured output results_file if necessary
         if self.results_file:
+            results_path = os.path.abspath(self.results_file)
 
             # create directory if not exists
-            os.makedirs(os.path.dirname(self.results_file), exist_ok=True)
+            os.makedirs(os.path.dirname(results_path), exist_ok=True)
 
             self.end_timestamp = datetime.datetime.now()
             self.metadata.update({"completed_at": self.end_timestamp.isoformat(timespec='microseconds')})
             self.metadata.update({"runtime_sec": (self.end_timestamp - self.start_timestamp).total_seconds()})
-            with open(self.results_file, 'w') as fp:
+            with open(results_path, 'w') as fp:
                 fp.write(json.dumps(self.metadata, indent=4))
 
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -397,7 +397,9 @@ class Earthmover:
             active_graph.draw()
         
         ### Create structured output results_file if necessary
-        if self.results_file:# create directory if not exists
+        if self.results_file:
+
+            # create directory if not exists
             os.makedirs(os.path.dirname(self.results_file), exist_ok=True)
 
             self.end_timestamp = datetime.datetime.now()

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -63,7 +63,8 @@ class Earthmover:
         self.force = force
         self.skip_hashing = skip_hashing
 
-        self.results_file = os.path.abspath(results_file)
+        self.results_file = os.path.abspath(results_file) if results_file else None
+        print(self.results_file)
         self.config_file = os.path.abspath(config_file)
         self.overrides = overrides
         self.compiled_yaml_file = COMPILED_YAML_FILE

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -63,7 +63,7 @@ class Earthmover:
         self.force = force
         self.skip_hashing = skip_hashing
 
-        self.results_file = results_file
+        self.results_file = os.path.abspath(results_file)
         self.config_file = os.path.abspath(config_file)
         self.overrides = overrides
         self.compiled_yaml_file = COMPILED_YAML_FILE
@@ -397,16 +397,13 @@ class Earthmover:
             active_graph.draw()
         
         ### Create structured output results_file if necessary
-        if self.results_file:
-            results_path = os.path.abspath(self.results_file)
-
-            # create directory if not exists
-            os.makedirs(os.path.dirname(results_path), exist_ok=True)
+        if self.results_file:# create directory if not exists
+            os.makedirs(os.path.dirname(self.results_file), exist_ok=True)
 
             self.end_timestamp = datetime.datetime.now()
             self.metadata.update({"completed_at": self.end_timestamp.isoformat(timespec='microseconds')})
             self.metadata.update({"runtime_sec": (self.end_timestamp - self.start_timestamp).total_seconds()})
-            with open(results_path, 'w') as fp:
+            with open(self.results_file, 'w') as fp:
                 fp.write(json.dumps(self.metadata, indent=4))
 
 

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -64,7 +64,6 @@ class Earthmover:
         self.skip_hashing = skip_hashing
 
         self.results_file = os.path.abspath(results_file) if results_file else None
-        print(self.results_file)
         self.config_file = os.path.abspath(config_file)
         self.overrides = overrides
         self.compiled_yaml_file = COMPILED_YAML_FILE

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -102,6 +102,7 @@ class FileSource(Source):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.file = self.error_handler.assert_get_key(self.config, 'file', dtype=str, required=False)
+        print(f"self.file: {self.file}")
 
         #
         if not self.file:

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -102,7 +102,6 @@ class FileSource(Source):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.file = self.error_handler.assert_get_key(self.config, 'file', dtype=str, required=False)
-        print(f"self.file: {self.file}")
 
         #
         if not self.file:

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -103,7 +103,7 @@ class Package:
                 for file_config in ('file', 'template'):
                     filepath = self.error_handler.assert_get_key(yaml_mapping[node_type][node], file_config, dtype=str, required=False, default=None)
                     if filepath and not os.path.isabs(filepath):
-                        yaml_mapping[node_type][node][file_config] = os.path.join(self.package_path, filepath.strip('./'))
+                        yaml_mapping[node_type][node][file_config] = os.path.abspath(os.path.join(self.package_path, filepath))
 
         # Replace relative paths for any map files in map_values operations
         for transformation in self.error_handler.assert_get_key(yaml_mapping, 'transformations', dtype=dict, required=False, default={}):

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -102,7 +102,7 @@ class Package:
                 # These are the current key names that denote filepaths
                 for file_config in ('file', 'template'):
                     filepath = self.error_handler.assert_get_key(yaml_mapping[node_type][node], file_config, dtype=str, required=False, default=None)
-                    if filepath and not os.path.isabs(filepath) and "://" not in self.file:
+                    if filepath and not os.path.isabs(filepath) and "://" not in filepath:
                         # remap LOCAL + RELATIVE filepaths
                         yaml_mapping[node_type][node][file_config] = os.path.abspath(os.path.join(self.package_path, filepath))
 

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -102,7 +102,8 @@ class Package:
                 # These are the current key names that denote filepaths
                 for file_config in ('file', 'template'):
                     filepath = self.error_handler.assert_get_key(yaml_mapping[node_type][node], file_config, dtype=str, required=False, default=None)
-                    if filepath and not os.path.isabs(filepath):
+                    if filepath and not os.path.isabs(filepath) and "://" not in self.file:
+                        # remap LOCAL + RELATIVE filepaths
                         yaml_mapping[node_type][node][file_config] = os.path.abspath(os.path.join(self.package_path, filepath))
 
         # Replace relative paths for any map files in map_values operations

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -144,7 +144,10 @@ class LocalPackage(Package):
         """
         super().install(packages_dir)
 
-        source_path = self.error_handler.assert_get_key(self.config, 'local', dtype=str, required=False)
+        # In order to handle nested dependencies, search for sub-packages
+        #   relative to the parent package's earthmover.yaml
+        source_dir = self.error_handler.assert_get_key(self.config, 'local', dtype=str, required=False)
+        source_path = os.path.join(os.path.dirname(self.config.__file__), source_dir)
 
         if not os.path.exists(source_path):
             self.error_handler.throw(


### PR DESCRIPTION
## Nested local packages
Given the following setup:
  - `pkg_A` depends on `pkg_B` (doesn't matter how)
  - `pkg_B` has `pkg_C` as a **local** dependency
  - You run `earthmover deps` on `pkg_A`

This fails because Earthmover looks for the path to `pkg_C` relative to `pkg_A/earthmover.yaml` instead of `pkg_B/earthmover.yaml`, and can't find it.

## Resolving relative filepaths
Bug spelled out [here](https://edanalytics.slite.com/app/docs/2ici_xnKjKVy-s#f8925219) -- fix was removing the `.strip('./')` from the `load_package_yaml` function

## Allow simple filepaths as `results-file`

Currently we require `--results-file ./results.json` and forbid `--results-file results.json`. The latter should be allowed too

Tested the fixes locally but couldn't hurt for others to try it out as well.