### PR TITLE
Refactor Source columns list logic as a select instead of a rename.

### DIFF
--- a/example_projects/07_filetypes/earthmover.yaml
+++ b/example_projects/07_filetypes/earthmover.yaml
@@ -17,6 +17,7 @@ sources:
     # ^ from https://github.com/Teradata/kylo/tree/master/samples/sample-data/orc
     #   (note that you need to `pip install pyarrow` before you can run earthmover with parquet files)
     type: orc # this is necessary because the file doesn't end in .orc
+    rename_cols: True
     columns:
       - registration_dttm
       - id


### PR DESCRIPTION
This change replaces column alias logic with column select logic in defined sources.

@tomreitz This does not work for Example Project 07_filetypes on ORC files. We may want to make column renaming the optional behavior instead of the default.