### PR TITLE
Fix `earthmover deps` fails when not all params are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased chnages
+* bugfix: `earthmover deps` fails when imported package config references environment variables and those variables are not passed at the command line
+
 ### v0.4.1
 <details>
 <summary>Released 2024-11-15</summary>

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -140,6 +140,9 @@ class Earthmover:
                 # Combine `key: ${VAL}` with `VAL: default_val` to get `key: default_val`
                 template = string.Template(val)
                 try:
+                   # Especially in cases like 'deps' and 'compile,' there may be no params passed 
+                   # and no default defined. We should allow this but alert the user so that
+                   # any downstream errors during 'run' are more traceable
                    configs[key] = template.substitute(self.params)
                 except KeyError:
                     self.logger.warning(f"No value passed for config.{key}: {val} and no default defined")

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -139,13 +139,7 @@ class Earthmover:
             if isinstance(val, str):
                 # Combine `key: ${VAL}` with `VAL: default_val` to get `key: default_val`
                 template = string.Template(val)
-                try:
-                   # Especially in cases like 'deps' and 'compile,' there may be no params passed 
-                   # and no default defined. We should allow this but alert the user so that
-                   # any downstream errors during 'run' are more traceable
-                   configs[key] = template.substitute(self.params)
-                except KeyError:
-                    self.logger.warning(f"No value passed for config.{key}: {val} and no default defined")
+                configs[key] = template.safe_substitute(self.params)
 
         # 3. Prepend package macros to the project macro string. Later macro definitions in the string will overwrite earlier ones
         self.macros = configs.get("macros", "").strip() + self.macros

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -139,7 +139,10 @@ class Earthmover:
             if isinstance(val, str):
                 # Combine `key: ${VAL}` with `VAL: default_val` to get `key: default_val`
                 template = string.Template(val)
-                configs[key] = template.substitute(self.params)
+                try:
+                   configs[key] = template.substitute(self.params)
+                except KeyError:
+                    self.logger.warning(f"No value passed for config.{key}: {val} and no default defined")
 
         # 3. Prepend package macros to the project macro string. Later macro definitions in the string will overwrite earlier ones
         self.macros = configs.get("macros", "").strip() + self.macros


### PR DESCRIPTION
Fixes a bug introduced in #130 - thanks to @jayckaiser for reporting