### PR TITLE
fix optional fields recursion

### DIFF
--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -79,10 +79,21 @@ class Source(Node):
 
         # Add missing columns if defined under `optional_fields`.
         if self.optional_fields:
-            for field in self.optional_fields:
-                if field not in self.data.columns:
-                    self.logger.debug(f"Optional column will be added to dataset: '{field}'")
-                    self.data[field] = ""  # Default to empty string.
+            # Get all existing columns
+            existing_columns = self.data.columns.tolist()
+
+            # Combine existing columns with optional fields
+            all_columns = existing_columns + [col for col in self.optional_fields if col not in existing_columns]
+
+            # Construct a schema with all columns, initializing optional fields to empty strings
+            meta = pd.DataFrame(columns=all_columns)
+            meta = meta.astype({col: "object" for col in self.optional_fields})  # Ensure optional fields have correct type
+
+            # Apply to each partition
+            self.data = self.data.map_partitions(
+                lambda df: df.reindex(columns=all_columns, fill_value=""),
+                meta=meta
+            )
 
         super().post_execute(**kwargs)
 

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -83,7 +83,7 @@ class Source(Node):
             existing_columns = self.data.columns.tolist()
 
             # Combine existing columns with optional fields
-            all_columns = existing_columns + [col for col in self.optional_fields if col not in existing_columns]
+            all_columns = list(set(existing_columns).union(self.optional_fields))
 
             # Construct a schema with all columns, initializing optional fields to empty strings
             meta = pd.DataFrame(columns=all_columns)


### PR DESCRIPTION
rework optional fields creation to avoid recursive dataframe updates

I found that the recursion errors we were seeing in CIRCLE bundle likely traced back to this line
`self.data[field] = ""`

(something about dask doing checks under the hood each time a dataframe update happens)

I also wanted to resolve the repeated warnings we were receiving both before and after resolving the recursion:
```
PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling frame.insert many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use newframe = frame.copy()
```

Those warnings are now gone, I believe because of the change to construct the new columns separately & then reindex