### PR TITLE
initial implementation of column reference detection in Jinja templates

### DIFF
--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -94,6 +94,12 @@ class FileDestination(Destination):
 
             self.jinja_template = util.build_jinja_template(template_string, macros=self.earthmover.macros)
 
+            
+            params = util.get_jinja_template_params(template_string, self.earthmover.macros)
+            self.logger.debug(
+                f"($destinations.{self.name} uses params: {params})"
+            )
+
         except OSError as err:
             self.error_handler.throw(
                 f"`template` file {self.template} cannot be opened ({err})"

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -42,6 +42,10 @@ class AddColumnsOperation(Operation):
             else:
                 try:
                     template = util.build_jinja_template(val, macros=self.earthmover.macros)
+                    params = util.get_jinja_template_params(val, self.earthmover.macros)
+                    self.logger.debug(
+                        f"($transformations.{self.name} uses params: {params})"
+                    )
 
                 except Exception as err:
                     self.error_handler.ctx.remove('line')
@@ -100,6 +104,11 @@ class ModifyColumnsOperation(Operation):
         
         try:
             template = util.build_jinja_template(val, macros=self.earthmover.macros)
+            
+            params = util.get_jinja_template_params(val, self.earthmover.macros)
+            self.logger.debug(
+                f"($transformations.{self.name} uses params: {params})"
+            )
 
         except Exception as err:
             self.error_handler.ctx.remove('line')

--- a/earthmover/util.py
+++ b/earthmover/util.py
@@ -135,3 +135,17 @@ def build_jinja_template(template_string: str, macros: str = ""):
     template.globals['fromjson'] = lambda x: json.loads(x)
 
     return template
+
+def get_jinja_template_params(template_string: str, macros: str = ""):
+    """
+    This function uses Jinja's meta functions to return a list of variables
+    referenced within `template_string`. This may be used in the future to
+    trace column-level lineage backward through the data dependency graph,
+    and drop unused columns early (to improve earthmover performance).
+    """
+    from jinja2 import meta
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(os.path.dirname('./'))
+    )
+    ast = env.parse(macros.strip() + template_string)
+    return list(meta.find_undeclared_variables(ast))


### PR DESCRIPTION
@jayckaiser and I were discussing how to prune unused columns from `sources` early, to minimize earthmover's memory usage when processing wide data.

This **draft** PR (not ready for merge, just for discussion!)
* adds a function `util.get_jinja_template_params(template_string, macros)` which returns a list of parameters referenced by the Jinja template
* logs the params used by a `destination.template` and `add_columns`/`modify_columns` transformation `operations` when `config.log_level=DEBUG`

Using this concept, I think we could (theoretically)
* at compile time, walk _backwards_ through the graph (starting at destinations) and, at each node, build a list of upstream columns it references (like `[$sources.nodeA:col1, $transformations.nodeB:col1, $transformations.nodeB:col2]`) - this would require adding a method like `get_upstream_column_refs(downsteam_refs)` to each `operation`, which would be called to backpropagate column references all the way to the `sources`
* at run time, immediately `keep_columns` (or even only read columns, for source files types that support that) only the ref'd columns

One issue to discuss is how to handle "special" references, like `__row_data__` (which is [used](https://github.com/edanalytics/earthmover_edfi_bundles/blob/dd52b1e2bac61921c662ef1c3fd223f36e90641a/packages/student_ids/earthmover.yaml#L348), among other places, by [the `student_id` bundle](https://github.com/edanalytics/earthmover_edfi_bundles/blob/main/packages/student_ids/earthmover.yaml)). Options here include
* try to refactor `student_id` (and possibly other bundles) to not use `__row_data__` (I'm not actually sure this is possible...)
* if `__row_data__` is referenced, just don't do any column pruning (but this means any project that uses `student_id` won't benefit from pruning)
* try to descend into the Jinja AST and unpack _which elements of `__row_data__` are referenced_ (this sounds significantly more complicated)

Another thing to discuss is whether this "early pruning" is even the best approach, or should we leave such optimizations to the user and instead focus on making `drop_columns` and `keep_columns` more flexible, allowing wildcards or regex, so the user doesn't have to explicitly list all columns to keep/drop. (For example:)
```yaml
transformations:
  my_wide_data:
    source: $sources.my_wide_source
    operations:
      - operation: keep_columns # or `drop_columns`
        columns:
          - *_values     # prefixed columns, matches `my_values` and `your_values`
          - our_*        # suffixed columns, matches `our_values` and `our_data`
          - our_*_values # wildcard columns, matches `our_awesome_values` and `our_amazing_values`
          - *our_*_values # should we support multiple wildcards? would match `our_awesome_values` and `your_amazing_values`
```
or, with [regex](https://www.w3schools.com/python/python_regex.asp),
```yaml
transformations:
  my_wide_data:
    source: $sources.my_wide_source
    operations:
      - operation: keep_columns # or `drop_columns`
        regex: True
        columns:
          - "^our.*values$" # regex matches `our_awesome_values` and `our_amazing_values`
```

Again, I'm opening this PR to show that parsing the params ref'd by a Jinja template is possible, and to open up discussion of whether we actually want earthmover to try to do that.