### PR TITLE
fix: error messages for `keep_columns` and `drop_columns` do not specify the columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased changes
+* fix: error messages for `keep_columns` and `drop_columns` do not specify the columns
+
 ### v0.4.2
 <details>
 <summary>Released 2024-11-15</summary>

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -215,7 +215,7 @@ class DropColumnsOperation(Operation):
 
         if not set(self.columns_to_drop).issubset(data.columns):
             self.error_handler.throw(
-                "one or more columns specified to drop are not present in the dataset"
+                f"one or more columns specified to drop are not present in the dataset: {set(self.columns_to_drop).difference(data.columns)}"
             )
             raise
 
@@ -246,7 +246,7 @@ class KeepColumnsOperation(Operation):
 
         if not set(self.header).issubset(data.columns):
             self.error_handler.throw(
-                "one or more columns specified to keep are not present in the dataset"
+                f"one or more columns specified to keep are not present in the dataset: {set(self.header).difference(data.columns)}"
             )
             raise
 


### PR DESCRIPTION
Add the set difference of the columns to the error messages so the user knows what is missing