### PR TITLE
Feature/dask distributed

### DIFF
--- a/earthmover/__init__.py
+++ b/earthmover/__init__.py
@@ -5,6 +5,7 @@
 #    the bugs that emerge when we use it with Earthmover will have been fixed.
 import dask
 dask.config.set({'dataframe.query-planning': False})
+dask.config.set({"distributed.scheduler.worker-saturation": 1.0})
 
 # performance enhancements
 dask.config.set({"dataframe.convert-string": True})

--- a/earthmover/__init__.py
+++ b/earthmover/__init__.py
@@ -1,14 +1,3 @@
-# September 2024 - for now we need to do this in order to turn off the Dask 
-#    query optimizer - see https://blog.dask.org/2023/08/25/dask-expr-introduction
-#    For reasons unknown, it doesn't yet work with Earthmover. A future Dask 
-#    version may force us to use the query optimizer, but hopefully by then,
-#    the bugs that emerge when we use it with Earthmover will have been fixed.
-import dask
-dask.config.set({'dataframe.query-planning': False})
-dask.config.set({"distributed.scheduler.worker-saturation": 1.0})
-
-# performance enhancements
-dask.config.set({"dataframe.convert-string": True})
 import pandas as pd
 
 # only use upgraded pandas config on later versions of python

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -2,6 +2,10 @@ import argparse
 import logging
 import os
 import sys
+import dask
+
+from dask.distributed import LocalCluster, Client
+from concurrent.futures import ThreadPoolExecutor
 
 from earthmover.earthmover import Earthmover
 from earthmover.init import run_init
@@ -264,6 +268,27 @@ def main(argv=None):
         logger.exception(f"unknown command '{args.command}', use -h flag for help")
         raise
 
+dask.config.set({"tokenize.ensure-deterministic": False})
+cluster = LocalCluster(n_workers=2, # number of available cores minus 2?
+                threads_per_worker=1,# number of threads per core
+                memory_limit='2.0GB', # per worker; threads on a worker share this memory
+                processes=True,
+                silence_logs=logging.ERROR,
+                # dashboard_address=None, # to disable dashboard
+                local_directory='./',
+                # executor="loky",
+                )
+# Find how many cores and threads-per-core your system has with `lscpu`
+# Find how much memory is available on your system with `grep MemTotal /proc/meminfo`
+print(f"View the dask profiling dashboard at {cluster.dashboard_link}")
+dask_client = Client(cluster,
+                serializers=['pickle', 'msgpack'], # ['dill', 'msgpack', 'pickle']
+                deserializers=['pickle', 'msgpack'])
+
+# dask_client.get_versions(check=True)
+# dask.config.set(scheduler='processes')
+# dask.config.set(pool=ThreadPoolExecutor(4))
+# dask.config.set({"multiprocessing.context": "fork"})
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -4,7 +4,6 @@ import os
 import sys
 import dask
 
-from dask.distributed import LocalCluster, Client
 from concurrent.futures import ThreadPoolExecutor
 
 from earthmover.earthmover import Earthmover
@@ -267,28 +266,6 @@ def main(argv=None):
     else:
         logger.exception(f"unknown command '{args.command}', use -h flag for help")
         raise
-
-# dask.config.set({"tokenize.ensure-deterministic": False})
-# cluster = LocalCluster(n_workers=2, # number of available cores minus 2?
-#                 threads_per_worker=1,# number of threads per core
-#                 memory_limit='2.0GB', # per worker; threads on a worker share this memory
-#                 processes=True,
-#                 silence_logs=logging.ERROR,
-#                 # dashboard_address=None, # to disable dashboard
-#                 local_directory='./',
-#                 # executor="loky",
-#                 )
-# Find how many cores and threads-per-core your system has with `lscpu`
-# Find how much memory is available on your system with `grep MemTotal /proc/meminfo`
-# print(f"View the dask profiling dashboard at {cluster.dashboard_link}")
-# dask_client = Client(cluster,
-#                 serializers=['pickle', 'msgpack'], # ['dill', 'msgpack', 'pickle']
-#                 deserializers=['pickle', 'msgpack'])
-
-# dask_client.get_versions(check=True)
-# dask.config.set(scheduler='processes')
-# dask.config.set(pool=ThreadPoolExecutor(4))
-# dask.config.set({"multiprocessing.context": "fork"})
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/earthmover/__main__.py
+++ b/earthmover/__main__.py
@@ -268,22 +268,22 @@ def main(argv=None):
         logger.exception(f"unknown command '{args.command}', use -h flag for help")
         raise
 
-dask.config.set({"tokenize.ensure-deterministic": False})
-cluster = LocalCluster(n_workers=2, # number of available cores minus 2?
-                threads_per_worker=1,# number of threads per core
-                memory_limit='2.0GB', # per worker; threads on a worker share this memory
-                processes=True,
-                silence_logs=logging.ERROR,
-                # dashboard_address=None, # to disable dashboard
-                local_directory='./',
-                # executor="loky",
-                )
+# dask.config.set({"tokenize.ensure-deterministic": False})
+# cluster = LocalCluster(n_workers=2, # number of available cores minus 2?
+#                 threads_per_worker=1,# number of threads per core
+#                 memory_limit='2.0GB', # per worker; threads on a worker share this memory
+#                 processes=True,
+#                 silence_logs=logging.ERROR,
+#                 # dashboard_address=None, # to disable dashboard
+#                 local_directory='./',
+#                 # executor="loky",
+#                 )
 # Find how many cores and threads-per-core your system has with `lscpu`
 # Find how much memory is available on your system with `grep MemTotal /proc/meminfo`
-print(f"View the dask profiling dashboard at {cluster.dashboard_link}")
-dask_client = Client(cluster,
-                serializers=['pickle', 'msgpack'], # ['dill', 'msgpack', 'pickle']
-                deserializers=['pickle', 'msgpack'])
+# print(f"View the dask profiling dashboard at {cluster.dashboard_link}")
+# dask_client = Client(cluster,
+#                 serializers=['pickle', 'msgpack'], # ['dill', 'msgpack', 'pickle']
+#                 deserializers=['pickle', 'msgpack'])
 
 # dask_client.get_versions(check=True)
 # dask.config.set(scheduler='processes')

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -509,12 +509,15 @@ class Earthmover:
         package_graph = Graph(error_handler=self.error_handler)  # Tracks package hierarchy
 
         # Create a root package to be the root of the packages directed graph
+        print(configs)
         root_package = Package('root', configs, earthmover=self, package_path=os.path.dirname(self.config_file))
         root_package.config_file = self.config_file
         package_graph.add_node('root', package=root_package)
 
         package_config = self.error_handler.assert_get_key(configs, 'packages', dtype=dict, required=False, default={})
         for name, config in package_config.items():
+            print(name)
+            print(config)
             package = Package(name, config, earthmover=self)
             package_graph.add_node(name, package=package)
             package_graph.add_edge(root_package.name, name)
@@ -566,6 +569,8 @@ class Earthmover:
 
             # Add nested packages to packages_graph
             for name, config in nested_package_config.items():
+                print(name)
+                print(config)
                 nested_package = Package(name, config, earthmover=self)
                 self.package_graph.add_node(name, package=nested_package)
                 self.package_graph.add_edge(package_name, name)

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -102,6 +102,7 @@ class Earthmover:
 
         # Set the temporary directory in cases of disk-spillage.
         dask.config.set({'temporary_directory': self.state_configs['tmp_dir']})
+        
 
         # Set a directory for installing packages.
         self.packages_dir = os.path.join(os.getcwd(), 'packages')

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -537,15 +537,12 @@ class Earthmover:
         package_graph = Graph(error_handler=self.error_handler)  # Tracks package hierarchy
 
         # Create a root package to be the root of the packages directed graph
-        print(configs)
         root_package = Package('root', configs, earthmover=self, package_path=os.path.dirname(self.config_file))
         root_package.config_file = self.config_file
         package_graph.add_node('root', package=root_package)
 
         package_config = self.error_handler.assert_get_key(configs, 'packages', dtype=dict, required=False, default={})
         for name, config in package_config.items():
-            print(name)
-            print(config)
             package = Package(name, config, earthmover=self)
             package_graph.add_node(name, package=package)
             package_graph.add_edge(root_package.name, name)
@@ -597,8 +594,6 @@ class Earthmover:
 
             # Add nested packages to packages_graph
             for name, config in nested_package_config.items():
-                print(name)
-                print(config)
                 nested_package = Package(name, config, earthmover=self)
                 self.package_graph.add_node(name, package=nested_package)
                 self.package_graph.add_edge(package_name, name)

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -515,9 +515,8 @@ class Earthmover:
         package_graph.add_node('root', package=root_package)
 
         package_config = self.error_handler.assert_get_key(configs, 'packages', dtype=dict, required=False, default={})
+        print(package_config)
         for name, config in package_config.items():
-            print(name)
-            print(config)
             package = Package(name, config, earthmover=self)
             package_graph.add_node(name, package=package)
             package_graph.add_edge(root_package.name, name)

--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -164,7 +164,7 @@ class Earthmover:
         """
         ### Process the config_file and prepare for compilation.
         self.user_configs = JinjaEnvironmentYamlLoader.load_config_file(self.config_file, params=self.params, macros=self.macros)
-        # self.package_graph = self.build_root_package_graph(self.user_configs)
+        self.package_graph = self.build_root_package_graph(self.user_configs)
         self.graph = Graph(error_handler=self.error_handler)
 
         ### Optionally merge packages to update user-configs and write the composed YAML to disk.
@@ -256,10 +256,10 @@ class Earthmover:
         """
 
         # dask.config.set({"tokenize.ensure-deterministic": False})
-        cluster = LocalCluster(n_workers=4, # number of available cores minus 2?
+        cluster = LocalCluster(n_workers=6, # number of available cores minus 2?
                         threads_per_worker=1,# number of threads per core
                         memory_limit='2.0GB', # per worker; threads on a worker share this memory
-                        processes=True,
+                        processes=True, # try turning it on?
                         silence_logs=logging.ERROR,
                         # dashboard_address=None, # to disable dashboard
                         local_directory='./',
@@ -539,13 +539,13 @@ class Earthmover:
         # Create a root package to be the root of the packages directed graph
         root_package = Package('root', configs, earthmover=self, package_path=os.path.dirname(self.config_file))
         root_package.config_file = self.config_file
-        package_graph.add_node('root', package=root_package)
+        # package_graph.add_node('root', package=root_package)
 
-        package_config = self.error_handler.assert_get_key(configs, 'packages', dtype=dict, required=False, default={})
-        for name, config in package_config.items():
-            package = Package(name, config, earthmover=self)
-            package_graph.add_node(name, package=package)
-            package_graph.add_edge(root_package.name, name)
+        # package_config = self.error_handler.assert_get_key(configs, 'packages', dtype=dict, required=False, default={})
+        # for name, config in package_config.items():
+        #     package = Package(name, config, earthmover=self)
+        #     package_graph.add_node(name, package=package)
+        #     package_graph.add_edge(root_package.name, name)
 
         return package_graph
 

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -134,16 +134,13 @@ class FileDestination(Destination):
                     warnings.filterwarnings("ignore", message="Insufficient elements for `head`")
                     # (use `npartitions=-1` because the first N partitions could be empty)
                     # (use self.upstream_sources because self.data is a single column, the rendered Jinja template)
-                    first_row = {} # self.upstream_sources[self.source].data.head(1, npartitions=-1).reset_index(drop=True).iloc[0]
+                    first_row = pd.Series({}) # self.upstream_sources[self.source].data.head(1, npartitions=-1).reset_index(drop=True).iloc[0]
             
             except IndexError:  # If no rows are present, build a representation of the row with empty values
                 first_row = {col: "" for col in self.upstream_sources[self.source].data.columns}
                 first_row['__row_data__'] = first_row
                 first_row = pd.Series(first_row)
         
-        print(type(first_row))
-        print(first_row)
-
         # Write the optional header, each line
         if self.header:
             with open(self.file, 'a', encoding='utf-8') as fp:

--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -157,11 +157,12 @@ class FileDestination(Destination):
         # to_csv() unfortunately only works if `linearize: True`; otherwise, we get an error about
         # escapechar being required (since the non-linearized data might contain newline chars)
         # self.data.to_frame().to_csv(self.file, index=False, header=False, encoding='utf-8', mode='a', quoting=csv.QUOTE_NONE, doublequote=False, na_rep=" ", sep="~", escapechar='')
+        self.data.to_csv(self.file, single_file=False, index=False, header=False, encoding='utf-8', mode='a', quoting=csv.QUOTE_NONE, doublequote=False, na_rep=" ", sep="~", escapechar='')
         # so instead we need to
-        with open(self.file, 'a', encoding='utf-8') as fp:
-            for partition in self.data.partitions:
-                fp.writelines(partition.compute())
-                partition = None
+        # with open(self.file, 'a', encoding='utf-8') as fp:
+        #     for partition in self.data.partitions:
+        #         fp.writelines(partition.compute())
+        #         partition = None
         
         # Write the optional header, each line
         if self.footer:

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -26,6 +26,9 @@ class Node:
     type: str = None
     allowed_configs: Tuple[str] = ('debug', 'expect', 'require_rows', 'show_progress', 'repartition')
 
+    def __getnewargs__(self):
+        return self.name, self.config, self.earthmover
+
     def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
         self.name: str = name
         self.config: 'YamlMapping' = config
@@ -177,8 +180,8 @@ class Node:
                 result[expectation_result_col] = result.apply(
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=expectation_result_col),
-                    template=template,
-                    template_str="{{" + expectation + "}}",
+                    template_bytecode_file=template,
+                    template_string="{{" + expectation + "}}",
                     error_handler = self.error_handler
                 )
 

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -175,13 +175,15 @@ class Node:
             result = self.data.copy()
 
             for expectation in expectations:
-                template = jinja2.Template("{{" + expectation + "}}")
+                template_string = "{{" + expectation + "}}"
+                template = util.build_jinja_template(template_string=template_string, macros="")
 
                 result[expectation_result_col] = result.apply(
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=expectation_result_col),
                     template_bytecode_file=template,
-                    template_string="{{" + expectation + "}}",
+                    template_string=template_string,
+                    macros="",
                     error_handler = self.error_handler
                 )
 

--- a/earthmover/nodes/node.py
+++ b/earthmover/nodes/node.py
@@ -176,12 +176,12 @@ class Node:
 
             for expectation in expectations:
                 template_string = "{{" + expectation + "}}"
-                template = util.build_jinja_template(template_string=template_string, macros="")
+                # template = util.build_jinja_template(template_string=template_string, macros="")
 
                 result[expectation_result_col] = result.apply(
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=expectation_result_col),
-                    template_bytecode_file=template,
+                    jinja_environment=self.earthmover.jinja_environment,
                     template_string=template_string,
                     macros="",
                     error_handler = self.error_handler

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -27,7 +27,7 @@ class Source(Node):
     is_remote: bool = None
     allowed_configs: Tuple[str] = ('debug', 'expect', 'require_rows', 'show_progress', 'repartition', 'chunksize', 'optional', 'optional_fields',)
 
-    NUM_ROWS_PER_CHUNK: int = 1000000
+    NUM_ROWS_PER_CHUNK: int = 100
 
     def __new__(cls, name: str, config: 'YamlMapping', earthmover: 'Earthmover'):
         """
@@ -295,7 +295,8 @@ class FileSource(Source):
             dtype = str,
             encoding = config.get('encoding', "utf8"),
             keep_default_na = False,
-            skiprows = int(config.get('header_rows', 1)) - 1
+            skiprows = int(config.get('header_rows', 1)) - 1,
+            blocksize = '8MB'
             )
     
     def _verify_packages(self, file_type: str):

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -29,7 +29,7 @@ class Source(Node):
 
     NUM_ROWS_PER_CHUNK: int = 1000000
 
-    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
+    def __new__(cls, name: str, config: 'YamlMapping', earthmover: 'Earthmover'):
         """
         Logic for assigning sources to their respective classes.
 

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -41,7 +41,7 @@ class AddColumnsOperation(Operation):
 
             else:
                 try:
-                    template = util.build_jinja_template(val, macros=self.earthmover.macros)
+                    template = val # util.build_jinja_template(val, macros=self.earthmover.macros)
 
                 except Exception as err:
                     self.error_handler.ctx.remove('line')
@@ -54,7 +54,8 @@ class AddColumnsOperation(Operation):
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=col),
                     template=template,
-                    template_str=val,
+                    template_str=template,
+                    macros=self.earthmover.macros,
                     error_handler=self.error_handler
                 )
 
@@ -99,7 +100,7 @@ class ModifyColumnsOperation(Operation):
             return  # End immediately if no jinja processing is required.
         
         try:
-            template = util.build_jinja_template(val, macros=self.earthmover.macros)
+            template = val # util.build_jinja_template(val, macros=self.earthmover.macros)
 
         except Exception as err:
             self.error_handler.ctx.remove('line')
@@ -115,7 +116,8 @@ class ModifyColumnsOperation(Operation):
             util.render_jinja_template, axis=1,
             meta=pd.Series(dtype='str', name=col),
             template=template,
-            template_str=val,
+            template_str=template,
+            macros=self.earthmover.macros,
             error_handler=self.error_handler
         )
         del data["value"]

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -41,7 +41,7 @@ class AddColumnsOperation(Operation):
 
             else:
                 try:
-                    template_file = util.build_jinja_template(val, macros=self.earthmover.macros)
+                    template = util.build_jinja_template(self.earthmover.macros + val)
 
                 except Exception as err:
                     self.error_handler.ctx.remove('line')
@@ -53,9 +53,8 @@ class AddColumnsOperation(Operation):
                 data[col] = data.apply(
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=col),
-                    template_bytecode_file=template_file,
+                    template=template,
                     template_string=val,
-                    macros=self.earthmover.macros,
                     error_handler=self.error_handler
                 )
 
@@ -100,7 +99,7 @@ class ModifyColumnsOperation(Operation):
             return  # End immediately if no jinja processing is required.
         
         try:
-            template_file = util.build_jinja_template(val, macros=self.earthmover.macros)
+            template = util.build_jinja_template(self.earthmover.macros + val)
 
         except Exception as err:
             self.error_handler.ctx.remove('line')
@@ -115,7 +114,7 @@ class ModifyColumnsOperation(Operation):
         data[col] = data.apply(
             util.render_jinja_template, axis=1,
             meta=pd.Series(dtype='str', name=col),
-            template_bytecode_file=template_file,
+            template=template,
             template_string=val,
             macros=self.earthmover.macros,
             error_handler=self.error_handler

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -53,8 +53,8 @@ class AddColumnsOperation(Operation):
                 data[col] = data.apply(
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=col),
-                    template_file=template_file,
-                    template_str=val,
+                    template_bytecode_file=template_file,
+                    template_string=val,
                     macros=self.earthmover.macros,
                     error_handler=self.error_handler
                 )
@@ -115,8 +115,8 @@ class ModifyColumnsOperation(Operation):
         data[col] = data.apply(
             util.render_jinja_template, axis=1,
             meta=pd.Series(dtype='str', name=col),
-            template=template_file,
-            template_str=val,
+            template_bytecode_file=template_file,
+            template_string=val,
             macros=self.earthmover.macros,
             error_handler=self.error_handler
         )

--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -41,7 +41,7 @@ class AddColumnsOperation(Operation):
 
             else:
                 try:
-                    template = val # util.build_jinja_template(val, macros=self.earthmover.macros)
+                    template_file = util.build_jinja_template(val, macros=self.earthmover.macros)
 
                 except Exception as err:
                     self.error_handler.ctx.remove('line')
@@ -53,8 +53,8 @@ class AddColumnsOperation(Operation):
                 data[col] = data.apply(
                     util.render_jinja_template, axis=1,
                     meta=pd.Series(dtype='str', name=col),
-                    template=template,
-                    template_str=template,
+                    template_file=template_file,
+                    template_str=val,
                     macros=self.earthmover.macros,
                     error_handler=self.error_handler
                 )
@@ -100,7 +100,7 @@ class ModifyColumnsOperation(Operation):
             return  # End immediately if no jinja processing is required.
         
         try:
-            template = val # util.build_jinja_template(val, macros=self.earthmover.macros)
+            template_file = util.build_jinja_template(val, macros=self.earthmover.macros)
 
         except Exception as err:
             self.error_handler.ctx.remove('line')
@@ -115,8 +115,8 @@ class ModifyColumnsOperation(Operation):
         data[col] = data.apply(
             util.render_jinja_template, axis=1,
             meta=pd.Series(dtype='str', name=col),
-            template=template,
-            template_str=template,
+            template=template_file,
+            template_str=val,
             macros=self.earthmover.macros,
             error_handler=self.error_handler
         )

--- a/earthmover/operations/operation.py
+++ b/earthmover/operations/operation.py
@@ -17,7 +17,7 @@ class Operation(Node):
     type: str = "transformation"
     allowed_configs: Tuple[str] = ('operation', 'repartition',)
 
-    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover'):
+    def __new__(cls, name: str, config: 'YamlMapping', earthmover: 'Earthmover'):
         """
         :param config:
         :param earthmover:

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -15,10 +15,10 @@ class Package:
     """
     mode: str = None
 
-    def __getnewargs__(self):
-        return self.name, self.config
+    # def __getnewargs__(self):
+    #     return self.name, self.config
 
-    def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None):
+    def __new__(cls, name: str, config: 'YamlMapping', earthmover: 'Earthmover', package_path: Optional[str] = None):
         """
         Logic for assigning packages to their respective classes.
 
@@ -42,7 +42,7 @@ class Package:
             )
             raise
     
-    def __init__(self, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None):
+    def __init__(self, name: str, config: 'YamlMapping', earthmover: 'Earthmover', package_path: Optional[str] = None):
         self.name: str = name
         self.config: 'YamlMapping' = config
         self.earthmover: 'Earthmover' = earthmover
@@ -53,23 +53,23 @@ class Package:
 
         self.package_yaml: dict = None
 
-    def __getstate__(self):
-        print("I'm being pickled")
-        return {
-            "name": self.name,
-            "config": self.config,
-            "package_path": self.package_path,
-            "package_yaml": self.package_yaml,
-        }
+    # def __getstate__(self):
+    #     # print("I'm being pickled")
+    #     return {
+    #         "name": self.name,
+    #         "config": self.config,
+    #         "package_path": self.package_path,
+    #         "package_yaml": self.package_yaml,
+    #     }
 
-    def __setstate__(self, state):
-        print("I'm being unpickled with these values: " + repr(state))
-        self.name = state['name']
-        self.config = state['config']
-        self.package_path = state['package_path']
-        self.package_yaml = state['package_yaml']
-        self.logger = self.earthmover.logger
-        self.error_handler = self.earthmover.error_handler
+    # def __setstate__(self, state):
+    #     # print("I'm being unpickled with these values: " + repr(state))
+    #     self.name = state['name']
+    #     self.config = state['config']
+    #     self.package_path = state['package_path']
+    #     self.package_yaml = state['package_yaml']
+    #     self.logger = self.earthmover.logger
+    #     self.error_handler = self.earthmover.error_handler
 
     def install(self, packages_dir):
         """

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -15,6 +15,9 @@ class Package:
     """
     mode: str = None
 
+    def __getnewargs__(self):
+        return self.name, self.config
+
     def __new__(cls, name: str, config: 'YamlMapping', *, earthmover: 'Earthmover', package_path: Optional[str] = None):
         """
         Logic for assigning packages to their respective classes.
@@ -50,21 +53,23 @@ class Package:
 
         self.package_yaml: dict = None
 
-    # def __getstate__(self):
-    #     return {
-    #         "name": self.name,
-    #         "config": self.config,
-    #         "package_path": self.package_path,
-    #         "package_yaml": self.package_yaml,
-    #     }
+    def __getstate__(self):
+        print("I'm being pickled")
+        return {
+            "name": self.name,
+            "config": self.config,
+            "package_path": self.package_path,
+            "package_yaml": self.package_yaml,
+        }
 
-    # def __setstate__(self, state):
-    #     self.name = state['name']
-    #     self.config = state['config']
-    #     self.package_path = state['package_path']
-    #     self.package_yaml = state['package_yaml']
-    #     self.logger = self.earthmover.logger
-    #     self.error_handler = self.earthmover.error_handler
+    def __setstate__(self, state):
+        print("I'm being unpickled with these values: " + repr(state))
+        self.name = state['name']
+        self.config = state['config']
+        self.package_path = state['package_path']
+        self.package_yaml = state['package_yaml']
+        self.logger = self.earthmover.logger
+        self.error_handler = self.earthmover.error_handler
 
     def install(self, packages_dir):
         """

--- a/earthmover/package.py
+++ b/earthmover/package.py
@@ -50,6 +50,21 @@ class Package:
 
         self.package_yaml: dict = None
 
+    # def __getstate__(self):
+    #     return {
+    #         "name": self.name,
+    #         "config": self.config,
+    #         "package_path": self.package_path,
+    #         "package_yaml": self.package_yaml,
+    #     }
+
+    # def __setstate__(self, state):
+    #     self.name = state['name']
+    #     self.config = state['config']
+    #     self.package_path = state['package_path']
+    #     self.package_yaml = state['package_yaml']
+    #     self.logger = self.earthmover.logger
+    #     self.error_handler = self.earthmover.error_handler
 
     def install(self, packages_dir):
         """

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -125,12 +125,13 @@ class JinjaEnvironmentYamlLoader(yaml.SafeLoader):
 
         # Expand Jinja and complete full parsing
         try:
-            template_bytecode_file = util.build_jinja_template(raw_yaml, macros=macros)
+            # template_bytecode_file = util.build_jinja_template(raw_yaml, macros=macros)
             # empty_pd_df = pd.DataFrame()
             # empty_dask_df = dd.from_pandas(empty_pd_df, npartitions=1)
             # empty_row = dd.Series([], dtype=str)
-            raw_yaml = util.render_jinja_template(pd.Series(), template_bytecode_file, raw_yaml, macros, error_handler=None)
-            yaml_configs = yaml.load(raw_yaml, Loader=cls)
+            template = util.build_jinja_template(macros + raw_yaml)
+            parsed_yaml = util.render_jinja_template(pd.Series(), template, raw_yaml, error_handler=None)
+            yaml_configs = yaml.load(parsed_yaml, Loader=cls)
 
         except yaml.YAMLError as err:
             linear_error_message = " ".join(

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -125,11 +125,11 @@ class JinjaEnvironmentYamlLoader(yaml.SafeLoader):
 
         # Expand Jinja and complete full parsing
         try:
-            template_file = util.build_jinja_template(raw_yaml, macros=macros)
+            template_bytecode_file = util.build_jinja_template(raw_yaml, macros=macros)
             # empty_pd_df = pd.DataFrame()
             # empty_dask_df = dd.from_pandas(empty_pd_df, npartitions=1)
             # empty_row = dd.Series([], dtype=str)
-            raw_yaml = util.render_jinja_template(pd.Series(), template_file, raw_yaml, macros, error_handler=None)
+            raw_yaml = util.render_jinja_template(pd.Series(), template_bytecode_file, raw_yaml, macros, error_handler=None)
             yaml_configs = yaml.load(raw_yaml, Loader=cls)
 
         except yaml.YAMLError as err:

--- a/earthmover/yaml_parser.py
+++ b/earthmover/yaml_parser.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 import yaml
+import pandas as pd
 
 from string import Template
 from typing import Dict
@@ -124,7 +125,11 @@ class JinjaEnvironmentYamlLoader(yaml.SafeLoader):
 
         # Expand Jinja and complete full parsing
         try:
-            raw_yaml = util.build_jinja_template(raw_yaml, macros=macros).render()
+            template_file = util.build_jinja_template(raw_yaml, macros=macros)
+            # empty_pd_df = pd.DataFrame()
+            # empty_dask_df = dd.from_pandas(empty_pd_df, npartitions=1)
+            # empty_row = dd.Series([], dtype=str)
+            raw_yaml = util.render_jinja_template(pd.Series(), template_file, raw_yaml, macros, error_handler=None)
             yaml_configs = yaml.load(raw_yaml, Loader=cls)
 
         except yaml.YAMLError as err:

--- a/example_projects/01_simple/big_earthmover.yaml
+++ b/example_projects/01_simple/big_earthmover.yaml
@@ -3,8 +3,41 @@ version: 2
 config:
   output_dir: ./output/
   show_stacktrace: True
-  show_graph: True
-  log_level: DEBUG
+  # show_graph: True
+  # log_level: DEBUG
+  temp_dir: ./ # <- precedence over dask.temporary-directory
+  dask:
+    temporary-directory: /tmp
+    dataframe:
+      backend: pandas
+      convert-string: False
+      query-planning: False
+    multiprocessing:
+      context: fork
+    distributed:
+      scheduler:
+        active-memory-manager:
+          measure: managed
+        processes: True
+        worker-saturation: 1.0
+      worker:
+        memory:
+          recent-to-old-time: 5s # 600s
+          monitor-interval: 15s
+          rebalance:
+            measure: managed
+          spill: 0.5
+          pause: 0.95
+          terminate: 0.99
+          max-spill: false
+      nanny:
+        pre-spawn-environ:
+          MALLOC_TRIM_THRESHOLD_: 0
+  dask_cluster_kwargs:
+    n_workers: 4
+    threads_per_worker: 1
+    memory_limit: 1.2GB
+    processes: True
 
 sources:
   attendance:

--- a/example_projects/01_simple/big_earthmover.yaml
+++ b/example_projects/01_simple/big_earthmover.yaml
@@ -1,8 +1,10 @@
+version: 2
+
 config:
   output_dir: ./output/
-  # show_stacktrace: True
-  # show_graph: True
-  # log_level: DEBUG
+  show_stacktrace: True
+  show_graph: True
+  log_level: DEBUG
 
 sources:
   attendance:


### PR DESCRIPTION
This DRAFT PR is not yet ready for merge, however I want to explain what the work represents.

`earthmover` currently uses Dask (as opposed to Pandas, or other DataFrame libraries) for essentially one reason _only_: the ability to handle larger-then-memory data by spilling to disk. However, `earthmover`'s use of Dask is single-threaded... if you run `earthmover` on a large machine with (say) 32 cores, only one core will be used to do transformation.

Some transformation workloads you might want to run with `earthmover` are memory-bound: such workloads wouldn't benefit much or possibly at all from parallelizing Dask. However, some transformation workloads are compute-bound: such workloads could benefit from parallelization - possibly a lot.

This branch uses Dask's LocalCluster to parallelize workloads across a configurable number of concurrent workers (assigned to different cores on the machine). Initial tests on my laptop, with 16 CPU cores and 8GB memory, seem to show that this can make some workloads run faster.

In `example_projects/01_simple/` we have a `big_earthmover.yaml` which does a simple transformation on a 1B-row, 3.2GB TSV file and produces a 1B-line 27.9GB JSONL file.
* Under the most-recent released version of `earthmover`, this runs in **71 minutes**.
* Under this branch, with [the configured](https://github.com/edanalytics/earthmover/blob/6751be850895e2eef606d7a07615bec8fbd33983/example_projects/01_simple/big_earthmover.yaml#L37-L40) 4 cores with 1.2 GB memory each, it ran in **49 minutes** (30% improvement).

[I'll run some other workloads, including the TPC-H testbench at various input sizes, soon and post more benchmark results.]

To get this to work, several things had to be refactored in `earthmover`, especially because Dask parallelizes by serializing/pickling data and objects when it ships them to workers on another core. Some of the specific changes that were needed:
* use Python [partials](https://docs.python.org/3/library/functools.html#functools.partial) instead of [lambda expressions](https://docs.python.org/3/tutorial/controlflow.html#lambda-expressions) (which are not serializable)
* move Jinja template compilation into each partition (the method called by `.map_partitions()`) to deal with the fact that compiled Jinja templates are not serializable
* read input files with a smaller-than-default `blocksize`, since they get wider (and larger) when turned into JSONL in a destination
* write output files with `df.to_csv(self.file, single_file=True, ...)` to avoid each thread blocking on I/O
* remove extra `*` kwargs from several methods, which prevent object serialization

Further work to wrap up here includes:
* fixing the `Package` class and `deps` building process (currently commented out) which still throws Dask serialization errors
* document and determine reasonable defaults for earthmover.yml `config.dask` and `dask_cluster_kwargs` (possibly dynamic, based on host machine specs)