### PR TITLE
Update MANIFEST.in to fix `earthmover init`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 recursive-include earthmover/tests *.jsonl *.jsont *.yaml *.csv
 include earthmover/VERSION.txt requirements.txt
+include earthmover/include/starter_project/README.md
+include earthmover/include/starter_project/earthmover.yml


### PR DESCRIPTION
@oscarrezab pointed out that `pip install earthmover && earthmover init` fails with an error like "file `include/starter_project/README.md` not found". This is because we didn't add the starter project files to `MANIFEST.in`, so PyPI strips them out (it strips out all non-Python files, in fact) before packaging, leading to this error.

(We probably missed this because it _would_ work if you're using a local version of earthmover, i.e., `git clone ...earthmover && pip install -e .`.)

This PR specifically lists the files in `MANIFEST.in` so they'd be included in the package and `earthmover init` will work.