### PR TITLE
make `SqlSource`s hashable (work with state-tracking)

### DIFF
--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -292,9 +292,9 @@ class Earthmover:
             runs_file = RunsFile(_runs_path, earthmover=self)
 
             # Remote sources cannot be hashed; no hashed runs contain remote sources.
-            if any(source.is_remote for source in self.sources):
+            if any(not source.is_hashable for source in self.sources):
                 self.logger.info(
-                    "forcing regenerate, since some sources are remote (and we cannot know if they changed)"
+                    "forcing regenerate, since some sources are unhashable (so we cannot know if they changed)"
                 )
 
             elif any(hasattr(source, 'file') and os.path.isdir(source.file) for source in self.sources):

--- a/earthmover/nodes/source.py
+++ b/earthmover/nodes/source.py
@@ -23,7 +23,7 @@ class Source(Node):
     """
     type: str = 'source'
     mode: str = None  # Documents which class was chosen.
-    is_remote: bool = None
+    is_hashable: bool = None
     allowed_configs: Tuple[str] = ('debug', 'expect', 'require_rows', 'show_progress', 'repartition', 'chunksize', 'optional', 'optional_fields',)
 
     NUM_ROWS_PER_CHUNK: int = 1000000
@@ -103,7 +103,7 @@ class FileSource(Source):
 
     """
     mode: str = 'file'
-    is_remote: bool = False
+    is_hashable: bool = True
     allowed_configs: Tuple[str] = (
         'debug', 'expect', 'show_progress', 'repartition', 'chunksize', 'optional', 'optional_fields',
         'file', 'type', 'columns', 'header_rows', 'colspec_file', 'colspecs', 'colspec_headers', 'rename_cols',
@@ -160,7 +160,7 @@ class FileSource(Source):
 
         # Remote files cannot be size-checked in execute.
         if "://" in self.file:
-            self.is_remote = True
+            self.is_hashable = False
 
     def execute(self):
         """
@@ -179,7 +179,7 @@ class FileSource(Source):
             else:
                 dask_config.set({'dataframe.convert-string': False})
                 self.data = self.read_lambda(self.file, self.config)
-                if not self.is_remote:
+                if self.is_hashable:
                     self.size = os.path.getsize(self.file)
 
             # Rename columns if specified. Note that optional columns are ignored in this case.
@@ -386,7 +386,7 @@ class FtpSource(Source):
 
     """
     mode: str = 'ftp'
-    is_remote: bool = True
+    is_hashable: bool = False
     allowed_configs: Tuple[str] = (
         'debug', 'expect', 'show_progress', 'repartition', 'chunksize', 'optional', 'optional_fields',
         'connection', 'query',
@@ -450,7 +450,7 @@ class SqlSource(Source):
 
     """
     mode: str = 'sql'
-    is_remote: bool = True
+    is_hashable: bool = True
     allowed_configs: Tuple[str] = (
         'debug', 'expect', 'show_progress', 'repartition', 'chunksize', 'optional', 'optional_fields',
         'connection', 'query',


### PR DESCRIPTION
@AngelicaLastra pointed out that [state-tracking](https://edanalytics.github.io/earthmover/usage/#state) doesn't work with `SqlSource`s because they're remote. (This came up when [using a Snowflake connection to fetch studentIDs](https://github.com/edanalytics/earthmover_edfi_bundles/blob/019c5bfbb94dd24193cbfd19d2484df74ad7ff98/packages/student_ids/earthmover.yaml#L66-L99) for studentId matching with an [Ed-Fi bundle](https://github.com/edanalytics/earthmover_edfi_bundles).)

In discussing with Angelica and @jayckaiser, we realized that it would be possible to hash the results of a SQL query. This PR implements that via a few changes:
* change the `is_remote` property of `Source`s to `is_hashable` and marks `FileSource`s and `SqlSource`s hashable
* compute a hash for each row of data of a `SqlSource` - this hash can be stored in the `config.state_file`, and subsequent `earthmover run`s will skip if the SQL data has not changed

I've tested it with `example_projects/04_sqlalchemy/` and `earthmover run --set config.state_file ./.earthmover.csv`.

Some questions and comments:
1. This implementation results in the query being run twice (when state-tracking is enabled): once to compute the hash, and again when actually executing the data transformations.
1. The studentId query usually doesn't result in *huge* data, but in general a SQL query might. The performance on large datasets will be slower.
1. Should we consider making `is_hashable` a user-configurable value? it could be False by default for `SqlSource`s, but specialized earthmover projects that know what they're doing - like the studentID package - could set it to True to enable state-tracking.
1. I believe that Runway doesn't make use of earthmover's `state_file`, and I believe that earthbeam *can* but doesn't in most implementations. I may be helpful to have a broader discussion about using `state_file` in both tools.