### PR TITLE
prevent existing `value` column from being clobbered, if it exists

### DIFF
--- a/earthmover/operations/column.py
+++ b/earthmover/operations/column.py
@@ -105,6 +105,11 @@ class ModifyColumnsOperation(Operation):
             raise
 
         # TODO: Allow user to specify string that represents current column value.
+        if 'value' in data.columns:
+            # prevent existing `value` column from being clobbered, if it exists
+            self.error_handler.throw(
+                f"error in `modify_columns` operation; a column named `value` already exists, and would be removed by this operation... please rename it before using `modify_columns`"
+            )
         data['value'] = data[col]
 
         data[col] = data.apply(


### PR DESCRIPTION
This is the feature we discussed, @jayckaiser, to throw an error in `modify_columns` operations if the dataframe already contains a column named `value` - this will prevent such a column from silently being deleted.

I tested it, it works nicely. Tagging you to review.