### PR TITLE
fix column jumbling when using `optional_columns`

### DIFF
--- a/earthmover/nodes/destination.py
+++ b/earthmover/nodes/destination.py
@@ -2,7 +2,6 @@ import os
 import pandas as pd
 import re
 import warnings
-from collections import OrderedDict
 
 from earthmover.nodes.node import Node
 from earthmover import util
@@ -160,7 +159,7 @@ class FileDestination(Destination):
         self.size = os.path.getsize(self.file)
 
     def render_row(self, row: pd.Series, jinja_template):
-        row_data = row if isinstance(row, dict) else row.to_dict(into=OrderedDict)
+        row_data = row if isinstance(row, dict) else row.to_dict()
         row_data = {
             field: self.cast_output_dtype(value)
             for field, value in row_data.items()


### PR DESCRIPTION
This PR fixes a bug where, when a source defines `optional_columns`, the way they were added to the dataframe caused _all_ the columns to be jumbled into a random order. (This causes problems if you want to output some rows back in the same input format, like [the student_ids bundle](https://github.com/edanalytics/earthmover_edfi_bundles/tree/main/packages/student_ids) does with no-match students.)

The main fix was, when adding missing `optional_columns` to a `source` dataframe, instead of using
```
existing_columns.union(optional_columns)
```
to append them at the end
```
exiting_columns + optional_columns.difference(existing_columns)
```

**Note that the additional `optional_columns` will still be at the end of the dataframe**, even if they didn't exist in the original `source`. I think that's ok, let me know if not. (Removing them would be significantly more difficult, requiring passing the original column list all the way through all transformations between the `source` and `destination`.)

I also updated `destination.py` to, when turning a row into a dictionary to be rendered with Jinja, use `OrderedDict` instead of regular `dict`. This may not be necessary - I don't think we've seen any problems here, but in theory at least, `dict` could result in _each row_ having different key order which, when used with a Jinja template that loops over the dict keys (like [this](https://github.com/edanalytics/earthmover_edfi_bundles/blob/main/packages/student_ids/verbatim.csvt)), could mean completely jumbled data in the output. This change ensures that should not happen.

(I've tested this, both with[ the SC_READY bundle](https://github.com/edanalytics/earthmover_edfi_bundles/tree/main/assessments/SC_READY) with student ID matching, and with the test suite and `example_projects/`.)