### PR TITLE
Fix: Update default `value_name` in `melt` operator

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -612,9 +612,9 @@ The above example shows a transformation of the courses source, which consists o
             id_vars: student_id
             # Column(s) from the wide dataset to translate into values of the "variable" columns. If omitted, melt all columns not in id_vars. 
             value_vars: [math_score, reading_score, science_score, writing_score]
-            # Optional name of the column containing value_vars. efault to "variable"
+            # Optional name of the column containing value_vars. default to "melt_variable"
             var_name: subject
-            # Optional name of the column containing the values of the value_vars columns. Default to "value"
+            # Optional name of the column containing the values of the value_vars columns. Default to "melt_value"
             value_name: score
     ```
 
@@ -623,7 +623,7 @@ The above example shows a transformation of the courses source, which consists o
     Opposite of `melt` - pivots a source from long to wide format, where the unique values of old columns become the column names of new ones
 
     ```yaml
-        - operation: melt
+        - operation: pivot
             sources:
             - $sources.melted_scores
             # Column in long dataset whose unique values are names of columns in the wide dataset - to pivot by multiple columns, use sequential pivots

--- a/earthmover/operations/dataframe.py
+++ b/earthmover/operations/dataframe.py
@@ -272,9 +272,9 @@ class MeltOperation(Operation):
             self.error_handler.throw(f"`value_vars` must be a string or list, got {type(self.value_vars)}")
 
         # name for the new column that will hold the unpivoted column names
-        self.var_name = self.error_handler.assert_get_key(self.config, 'var_name', dtype=str, required=False, default='variable')
+        self.var_name = self.error_handler.assert_get_key(self.config, 'var_name', dtype=str, required=False, default='melt_variable')
         # name for the new column that will hold the values
-        self.value_name = self.error_handler.assert_get_key(self.config, 'value_name', dtype=str, required=False, default='value')
+        self.value_name = self.error_handler.assert_get_key(self.config, 'value_name', dtype=str, required=False, default='melt_value')
 
     def execute(self, data: 'DataFrame', **kwargs) -> 'DataFrame':
         super().execute(data, **kwargs)


### PR DESCRIPTION
In a similar vein to #170, removing a very likely source of `'value'` columns in dataframes.