### PR TITLE
Use removeprefix instead of lstrip

### DIFF
--- a/earthmover/earthmover.py
+++ b/earthmover/earthmover.py
@@ -150,8 +150,9 @@ class Earthmover:
         # parse self.overrides into configs:
         if self.overrides:
             for key, value in self.overrides.items():
-                if not prefix or key.startswith(prefix):
-                    configs.set_path(key.lstrip(prefix), value)
+                if prefix and key.startswith(prefix):
+                    key = key.removeprefix(prefix)
+                configs.set_path(key, value)
         return configs
 
     def compile(self, to_disk: bool = False):


### PR DESCRIPTION
Fixes #173 

Testing Instructions:

* Regression test: no existing behavior should break
* Setting the output_dir from the command line should now work: `--set config.output_dir ./some_dir`