### PR TITLE
fix bug in `earthmover init`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 recursive-include earthmover/tests *.jsonl *.jsont *.yaml *.csv
 include earthmover/VERSION.txt requirements.txt
 include earthmover/include/starter_project/README.md
-include earthmover/include/starter_project/earthmover.yml
+include earthmover/include/starter_project/earthmover.yaml


### PR DESCRIPTION
The actual file is `.yaml` but we had `.yml` in the `MANIFEST.in`. So `earthmover init` might work if you had installed with
```bash
git clone ...
cd earthmover/
pip install -e .
```
(and thus have the starter file). But if you simply did `pip install earthmover` you wouldn't have the starter file, and `earthmover init` would fail with a "file not found" error.