### PR TITLE
add jinja imports to test suite of `example_projects/`

### DIFF
--- a/example_projects/09_edfi/earthmover.yaml
+++ b/example_projects/09_edfi/earthmover.yaml
@@ -54,9 +54,12 @@ transformations:
   all_students:
     source: $sources.students_anytown
     operations:
+      {% from 'imports_test.jinja' import imports_work %}
+      {% if imports_work %}
       - operation: union
         sources:
           - $sources.students_someville
+      {% endif %}
       # add district_id:
       - operation: join
         sources:

--- a/example_projects/09_edfi/imports_test.jinja
+++ b/example_projects/09_edfi/imports_test.jinja
@@ -1,0 +1,1 @@
+{% set imports_work = True %}


### PR DESCRIPTION
This PR adds a jinja import to `example_project/` 09 - which is also included via composition in example 11 - to ensure test coverage for [the bug Alex](https://github.com/edanalytics/earthmover/issues/177) found in the future.

Under the current `main` branch, `earthmover` crashes with `'imports_test.jinja' not found in search path` on `example_projects/11_composition/`. Under [Alex'x fix PR](https://github.com/edanalytics/earthmover/pull/178), it works great!