### PR TITLE
Export file reading functionality

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 This page tracks releases of `earthmover`, with a summary of what was changed, fixed, added in each new version.
 
+## Unreleased changes
+
+* feature: Export file reading functionality `read_compiled_source` and `read_file`
+
 
 ## 2026 releases
 

--- a/earthmover/__init__.py
+++ b/earthmover/__init__.py
@@ -17,6 +17,5 @@ if sys.version_info.minor >= 10:
     pd.options.mode.copy_on_write = True
     pd.options.mode.string_storage = "pyarrow"
 
-# Public, importable file reader (reuses Earthmover's FileSource).
-# Usage: `from earthmover import read_file, read_source`
-from earthmover.reader import read_file, read_source
+# export the file reader so callers can open dataframes from a compiled project
+from earthmover.reader import read_file, read_compiled_source

--- a/earthmover/__init__.py
+++ b/earthmover/__init__.py
@@ -16,3 +16,7 @@ if sys.version_info.minor >= 10:
     import pandas as pd
     pd.options.mode.copy_on_write = True
     pd.options.mode.string_storage = "pyarrow"
+
+# Public, importable file reader (reuses Earthmover's FileSource).
+# Usage: `from earthmover import read_file, read_source`
+from earthmover.reader import read_file, read_source

--- a/earthmover/reader.py
+++ b/earthmover/reader.py
@@ -1,62 +1,37 @@
 """
 Standalone file-reading interface for Earthmover.
 
-This module exposes Earthmover's file reader (the same code path used by a normal
-`earthmover run`) as a plain function that returns a dataframe, without requiring a
-config file, an output directory, or a full DAG execution. It is intended for callers
-(e.g. Runway's executor) that need to read a source file into memory *exactly* as
-Earthmover would, while reusing all of Earthmover's existing configuration surface
-(`header_rows`, `colspec_file`, `encoding`, `type`, `columns`, etc.).
+Exposes Earthmover's `FileSource` reader as a plain function returning a dataframe,
+without a full DAG execution. Two entry points:
 
-Two entry points:
-- `read_file(file, config)` -- read a file given its path and an explicit source config.
-- `read_source(config_file, source_name)` -- read a source named in an existing
-  earthmover.yaml, pulling its config (and resolving paths/Jinja/macros) from that file
-  so you don't have to re-encode `header_rows`/`colspec_file`/etc. anywhere else.
+- `read_file(file, config)` -- read a file given its path and a dict of source config.
+- `read_compiled_source(source_name, compiled_config)` -- read a source by name from an
+  `earthmover_compiled.yaml`.
 
-Notes for callers:
-- File reads go through `FileSource`, which raises a plain `Exception` on error (via
-  the project's `ErrorHandler`). Nothing in this path calls `exit()` or prints a
-  stacktrace -- those behaviors live only in the CLI (`__main__.py`) and in
-  `Earthmover.generate()`. So errors are catchable normally.
-- For `read_file`, pass only recognized Earthmover source-config keys; unrecognized keys
-  log a warning (the same warning a normal run would emit).
-- For `read_file`, relative `file:` paths are NOT resolved against a project directory
-  (there is no config file to chdir into) -- pass an absolute path. A `colspec_file` is
-  resolved relative to the origin of the config: the input file's directory for
-  `read_file`, or the earthmover.yaml's directory for `read_source`.
-- `read_source` parses only the named config file (Jinja, params, and `config.macros`
-  are applied, mirroring a real run). It does NOT merge `packages:`, so a source defined
-  only inside an installed package will not be found.
 """
-import json
 import logging
 import os
 
+import yaml
+
 from earthmover.error_handler import ErrorHandler
 from earthmover.nodes.source import FileSource
-from earthmover.yaml_parser import JinjaEnvironmentYamlLoader, YamlMapping
+from earthmover.yaml_parser import YamlMapping
 
-from typing import Optional, Union
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    import pandas as pd
+from typing import Optional
 
 
 # Module-level logger; callers may pass their own.
-# Note: the level must be set explicitly. `Node` enables debug mode (which prints the
-# dataframe head to stdout) when `logger.level <= DEBUG`, and a fresh logger defaults to
-# NOTSET (0), which would wrongly trigger that. The CLI avoids this by setting INFO too.
+# Set the level explicitly: `Node` treats a NOTSET logger (level 0) as debug mode and
+# prints the dataframe head to stdout. The CLI avoids this by setting INFO too.
 _default_logger = logging.getLogger("earthmover.reader")
 _default_logger.setLevel(logging.INFO)
 
 
 class _ReaderContext:
     """
-    Minimal stand-in for an `Earthmover` instance, exposing only the attributes a
-    `Source` node touches during construction and reading: `logger`, `error_handler`,
-    and `state_configs`. This lets us reuse `FileSource` without spinning up a full
-    Earthmover project (config file, output dir, package graph, etc.).
+    Minimal stand-in for an `Earthmover` instance, exposing only what a `Source` node
+    touches during construction and reading: `logger`, `error_handler`, `state_configs`.
     """
     def __init__(self, logger: logging.Logger, error_handler: ErrorHandler):
         self.logger = logger
@@ -68,38 +43,28 @@ def read_file(
     file: str,
     config: Optional[dict] = None,
     *,
-    compute: bool = True,
+    materialize: bool = True,
     post_process: bool = True,
     logger: Optional[logging.Logger] = None,
 ):
     """
     Read a single file into a dataframe using Earthmover's `FileSource` reader.
 
-    :param file: Path to the file to read. Should be absolute (see module docstring).
-    :param config: Earthmover source config, e.g. {"type": "csv", "header_rows": 2,
-        "encoding": "latin1", "columns": [...]}. The `file` key is set automatically.
-        See `FileSource.allowed_configs` for the full set of recognized keys.
-    :param compute: If True (default), return an eager pandas DataFrame. If False,
-        return whatever the underlying reader produced (a Dask DataFrame for csv/tsv/
-        json/parquet/orc, a pandas DataFrame for excel/sas/spss/stata/feather/html/xml).
-    :param post_process: If True (default), apply Earthmover's standard post-read
-        processing -- this is the *faithful* behavior identical to `earthmover run`,
-        and it DROPS fully-empty rows (all-null or all-empty-string) and adds any
-        `optional_fields`. Set to False to skip post-processing and preserve 1:1 row
-        positions with the source file (needed if you intend to write values back by
-        row position).
-    :param logger: Optional logger; defaults to the module logger.
-    :return: A pandas DataFrame (compute=True) or a Dask/pandas DataFrame (compute=False).
+    :param file: path is not resolved relative to earthmover config - pass an absolute path
+    :param config: Earthmover source config as a dict, e.g. {"type": "csv", "header_rows": 2, ...}.
+    :param materialize: If True, return a materialized pandas dataframe; if False, return the
+        underlying reader's output. Default True
+    :param post_process: If True, apply Earthmover's standard post-read
+        processing - this drops fully-empty rows and adds `optional_fields`. 
+        Set False to preserve 1:1 row positions with the source file. Default True
+    :param logger: Optional logger.
     """
     logger = logger or _default_logger
-    file = os.fspath(file)
     abs_file = os.path.abspath(file)
 
-    # Build a YamlMapping config so the node can resolve relative resource paths (e.g. a
-    # `colspec_file`) and so error messages have a file reference. If the caller passed a
-    # YamlMapping that already carries an origin (i.e. it came from a parsed
-    # earthmover.yaml, via read_source), preserve it so `colspec_file` resolves relative
-    # to that file; otherwise anchor to the input file's directory.
+    # Build a YamlMapping so the node can resolve a relative `colspec_file` and error
+    # messages have a file reference. Preserve an origin carried by a passed YamlMapping;
+    # otherwise anchor to the input file's directory.
     origin = getattr(config, "__file__", None) or abs_file
     mapping = YamlMapping(__file__=origin, __line__=(getattr(config, "__line__", 0) or 0))
     if config:
@@ -116,86 +81,58 @@ def read_file(
         source.post_execute()
 
     data = source.data
-    if compute and hasattr(data, "compute"):
+    if materialize and hasattr(data, "compute"):
         data = data.compute()
     return data
 
 
-def read_source(
-    config_file: str,
+def read_compiled_source(
     source_name: str,
+    compiled_config: str,
     *,
-    params: Optional[Union[dict, str]] = None,
-    compute: bool = True,
+    materialize: bool = True,
     post_process: bool = True,
     logger: Optional[logging.Logger] = None,
 ):
     """
-    Read a single named source from an existing earthmover.yaml, reusing both its config
-    and Earthmover's reader -- so nothing about the source (header rows, colspecs,
-    encoding, column selection, ...) has to be re-encoded outside the bundle.
+    Read a named source from an `earthmover_compiled.yaml`.
 
-    The named config file is parsed exactly as a run would parse it (environment-variable
-    templating, `params`/`parameter_defaults`, and `config.macros` are all applied), the
-    requested source's config is pulled from the `sources:` block, its `file` path is
-    resolved relative to the config file, and the result is handed to `read_file`.
+    The compiled file is a fully-resolved project (packages merged, Jinja/params/macros
+    applied, `file:` paths absolute), so this just reads plain YAML, pulls the named
+    source, and hands it to `read_file`. Run `earthmover compile` first (and
+    `earthmover deps` if the project uses packages).
 
-    Limitations (kept out of scope for simplicity):
-    - `packages:` are NOT merged, so a source defined only inside an installed package
-      will not be found.
-    - File sources only -- a `connection`/`query` (SQL/FTP) source raises a clear error.
-
-    :param config_file: Path to the earthmover.yaml (or .yml) to read the source from.
     :param source_name: The key under `sources:` to read.
-    :param params: Optional run parameters, as a dict or a JSON string (mirrors the CLI
-        `-p`/`--params` flag). Overrides environment variables during templating.
-    :param compute: See `read_file`.
+    :param compiled_file: Path to the compiled YAML.
+    :param materialize: See `read_file`.
     :param post_process: See `read_file`.
-    :param logger: Optional logger; defaults to the module logger.
-    :return: A pandas DataFrame (compute=True) or a Dask/pandas DataFrame (compute=False).
+    :param logger: Optional logger.
     """
     logger = logger or _default_logger
-    config_file = os.path.abspath(os.fspath(config_file))
-    config_dir = os.path.dirname(config_file)
+    config = os.path.abspath(compiled_config)
 
-    # Normalize params (accept a dict or a JSON string, like the CLI).
-    if params is None:
-        params = {}
-    elif isinstance(params, str):
-        params = json.loads(params) if params else {}
-    else:
-        params = dict(params)
+    if not os.path.isfile(config):
+        raise FileNotFoundError(
+            f"compiled config not found at {config}"
+        )
 
-    # Mirror Earthmover's (non-package) config loading: pull parameter defaults and
-    # macros from the `config:` block, then fully parse the file with Jinja + macros.
-    project_configs = JinjaEnvironmentYamlLoader.load_project_configs(config_file, params=params)
-    for key, val in project_configs.get("parameter_defaults", {}).items():
-        params.setdefault(key, val)
-    macros = project_configs.get("macros", "").strip()
+    with open(config, "r", encoding="utf-8") as fp:
+        configs = yaml.safe_load(fp) or {}
 
-    user_configs = JinjaEnvironmentYamlLoader.load_config_file(config_file, params=params, macros=macros)
-
-    sources = user_configs.get("sources") or {}
+    sources = configs.get("sources") or {}
     if source_name not in sources:
         available = ", ".join(sorted(sources)) or "(none)"
-        raise Exception(
-            f"source `{source_name}` not found in {config_file}. Available sources: {available}"
+        raise KeyError(
+            f"source `{source_name}` not found in {config}. Available sources: {available}"
         )
 
     source_config = sources[source_name]
     if "file" not in source_config:
-        raise Exception(
-            f"source `{source_name}` in {config_file} is not a file source "
-            f"(read_source supports file sources only, not SQL/FTP `connection` sources)"
+        raise TypeError(
+            f"source `{source_name}` in {config} is not a file source, so is not supported"
         )
 
-    # Resolve the source's `file` relative to the config file's directory (a real run
-    # does this by chdir-ing to the config file's location before reading).
-    src_file = source_config["file"]
-    if not os.path.isabs(src_file):
-        src_file = os.path.join(config_dir, src_file)
-
     return read_file(
-        src_file, source_config,
-        compute=compute, post_process=post_process, logger=logger,
+        source_config["file"], source_config,
+        materialize=materialize, post_process=post_process, logger=logger,
     )

--- a/earthmover/reader.py
+++ b/earthmover/reader.py
@@ -1,0 +1,201 @@
+"""
+Standalone file-reading interface for Earthmover.
+
+This module exposes Earthmover's file reader (the same code path used by a normal
+`earthmover run`) as a plain function that returns a dataframe, without requiring a
+config file, an output directory, or a full DAG execution. It is intended for callers
+(e.g. Runway's executor) that need to read a source file into memory *exactly* as
+Earthmover would, while reusing all of Earthmover's existing configuration surface
+(`header_rows`, `colspec_file`, `encoding`, `type`, `columns`, etc.).
+
+Two entry points:
+- `read_file(file, config)` -- read a file given its path and an explicit source config.
+- `read_source(config_file, source_name)` -- read a source named in an existing
+  earthmover.yaml, pulling its config (and resolving paths/Jinja/macros) from that file
+  so you don't have to re-encode `header_rows`/`colspec_file`/etc. anywhere else.
+
+Notes for callers:
+- File reads go through `FileSource`, which raises a plain `Exception` on error (via
+  the project's `ErrorHandler`). Nothing in this path calls `exit()` or prints a
+  stacktrace -- those behaviors live only in the CLI (`__main__.py`) and in
+  `Earthmover.generate()`. So errors are catchable normally.
+- For `read_file`, pass only recognized Earthmover source-config keys; unrecognized keys
+  log a warning (the same warning a normal run would emit).
+- For `read_file`, relative `file:` paths are NOT resolved against a project directory
+  (there is no config file to chdir into) -- pass an absolute path. A `colspec_file` is
+  resolved relative to the origin of the config: the input file's directory for
+  `read_file`, or the earthmover.yaml's directory for `read_source`.
+- `read_source` parses only the named config file (Jinja, params, and `config.macros`
+  are applied, mirroring a real run). It does NOT merge `packages:`, so a source defined
+  only inside an installed package will not be found.
+"""
+import json
+import logging
+import os
+
+from earthmover.error_handler import ErrorHandler
+from earthmover.nodes.source import FileSource
+from earthmover.yaml_parser import JinjaEnvironmentYamlLoader, YamlMapping
+
+from typing import Optional, Union
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+# Module-level logger; callers may pass their own.
+# Note: the level must be set explicitly. `Node` enables debug mode (which prints the
+# dataframe head to stdout) when `logger.level <= DEBUG`, and a fresh logger defaults to
+# NOTSET (0), which would wrongly trigger that. The CLI avoids this by setting INFO too.
+_default_logger = logging.getLogger("earthmover.reader")
+_default_logger.setLevel(logging.INFO)
+
+
+class _ReaderContext:
+    """
+    Minimal stand-in for an `Earthmover` instance, exposing only the attributes a
+    `Source` node touches during construction and reading: `logger`, `error_handler`,
+    and `state_configs`. This lets us reuse `FileSource` without spinning up a full
+    Earthmover project (config file, output dir, package graph, etc.).
+    """
+    def __init__(self, logger: logging.Logger, error_handler: ErrorHandler):
+        self.logger = logger
+        self.error_handler = error_handler
+        self.state_configs = {"show_progress": False}
+
+
+def read_file(
+    file: str,
+    config: Optional[dict] = None,
+    *,
+    compute: bool = True,
+    post_process: bool = True,
+    logger: Optional[logging.Logger] = None,
+):
+    """
+    Read a single file into a dataframe using Earthmover's `FileSource` reader.
+
+    :param file: Path to the file to read. Should be absolute (see module docstring).
+    :param config: Earthmover source config, e.g. {"type": "csv", "header_rows": 2,
+        "encoding": "latin1", "columns": [...]}. The `file` key is set automatically.
+        See `FileSource.allowed_configs` for the full set of recognized keys.
+    :param compute: If True (default), return an eager pandas DataFrame. If False,
+        return whatever the underlying reader produced (a Dask DataFrame for csv/tsv/
+        json/parquet/orc, a pandas DataFrame for excel/sas/spss/stata/feather/html/xml).
+    :param post_process: If True (default), apply Earthmover's standard post-read
+        processing -- this is the *faithful* behavior identical to `earthmover run`,
+        and it DROPS fully-empty rows (all-null or all-empty-string) and adds any
+        `optional_fields`. Set to False to skip post-processing and preserve 1:1 row
+        positions with the source file (needed if you intend to write values back by
+        row position).
+    :param logger: Optional logger; defaults to the module logger.
+    :return: A pandas DataFrame (compute=True) or a Dask/pandas DataFrame (compute=False).
+    """
+    logger = logger or _default_logger
+    file = os.fspath(file)
+    abs_file = os.path.abspath(file)
+
+    # Build a YamlMapping config so the node can resolve relative resource paths (e.g. a
+    # `colspec_file`) and so error messages have a file reference. If the caller passed a
+    # YamlMapping that already carries an origin (i.e. it came from a parsed
+    # earthmover.yaml, via read_source), preserve it so `colspec_file` resolves relative
+    # to that file; otherwise anchor to the input file's directory.
+    origin = getattr(config, "__file__", None) or abs_file
+    mapping = YamlMapping(__file__=origin, __line__=(getattr(config, "__line__", 0) or 0))
+    if config:
+        for key, value in config.items():
+            mapping[key] = value
+    mapping["file"] = abs_file
+
+    error_handler = ErrorHandler(file=origin)
+    context = _ReaderContext(logger=logger, error_handler=error_handler)
+
+    source = FileSource("__read_file__", mapping, earthmover=context)
+    source.execute()
+    if post_process:
+        source.post_execute()
+
+    data = source.data
+    if compute and hasattr(data, "compute"):
+        data = data.compute()
+    return data
+
+
+def read_source(
+    config_file: str,
+    source_name: str,
+    *,
+    params: Optional[Union[dict, str]] = None,
+    compute: bool = True,
+    post_process: bool = True,
+    logger: Optional[logging.Logger] = None,
+):
+    """
+    Read a single named source from an existing earthmover.yaml, reusing both its config
+    and Earthmover's reader -- so nothing about the source (header rows, colspecs,
+    encoding, column selection, ...) has to be re-encoded outside the bundle.
+
+    The named config file is parsed exactly as a run would parse it (environment-variable
+    templating, `params`/`parameter_defaults`, and `config.macros` are all applied), the
+    requested source's config is pulled from the `sources:` block, its `file` path is
+    resolved relative to the config file, and the result is handed to `read_file`.
+
+    Limitations (kept out of scope for simplicity):
+    - `packages:` are NOT merged, so a source defined only inside an installed package
+      will not be found.
+    - File sources only -- a `connection`/`query` (SQL/FTP) source raises a clear error.
+
+    :param config_file: Path to the earthmover.yaml (or .yml) to read the source from.
+    :param source_name: The key under `sources:` to read.
+    :param params: Optional run parameters, as a dict or a JSON string (mirrors the CLI
+        `-p`/`--params` flag). Overrides environment variables during templating.
+    :param compute: See `read_file`.
+    :param post_process: See `read_file`.
+    :param logger: Optional logger; defaults to the module logger.
+    :return: A pandas DataFrame (compute=True) or a Dask/pandas DataFrame (compute=False).
+    """
+    logger = logger or _default_logger
+    config_file = os.path.abspath(os.fspath(config_file))
+    config_dir = os.path.dirname(config_file)
+
+    # Normalize params (accept a dict or a JSON string, like the CLI).
+    if params is None:
+        params = {}
+    elif isinstance(params, str):
+        params = json.loads(params) if params else {}
+    else:
+        params = dict(params)
+
+    # Mirror Earthmover's (non-package) config loading: pull parameter defaults and
+    # macros from the `config:` block, then fully parse the file with Jinja + macros.
+    project_configs = JinjaEnvironmentYamlLoader.load_project_configs(config_file, params=params)
+    for key, val in project_configs.get("parameter_defaults", {}).items():
+        params.setdefault(key, val)
+    macros = project_configs.get("macros", "").strip()
+
+    user_configs = JinjaEnvironmentYamlLoader.load_config_file(config_file, params=params, macros=macros)
+
+    sources = user_configs.get("sources") or {}
+    if source_name not in sources:
+        available = ", ".join(sorted(sources)) or "(none)"
+        raise Exception(
+            f"source `{source_name}` not found in {config_file}. Available sources: {available}"
+        )
+
+    source_config = sources[source_name]
+    if "file" not in source_config:
+        raise Exception(
+            f"source `{source_name}` in {config_file} is not a file source "
+            f"(read_source supports file sources only, not SQL/FTP `connection` sources)"
+        )
+
+    # Resolve the source's `file` relative to the config file's directory (a real run
+    # does this by chdir-ing to the config file's location before reading).
+    src_file = source_config["file"]
+    if not os.path.isabs(src_file):
+        src_file = os.path.join(config_dir, src_file)
+
+    return read_file(
+        src_file, source_config,
+        compute=compute, post_process=post_process, logger=logger,
+    )


### PR DESCRIPTION
Provide a file reader that can be imported and used with compiled Earthmover configs to turn an input path into a dataframe. Runway needs this in order to manipulate source files consistently with Earthmover's logic.

`read_compiled_source` takes in a named Earthmover **source** (i.e. not a path, but something like `input`) and a compiled Earthmover file and returns a dataframe (the caller can ask for an unmaterialized Dask dataframe). Requiring that the config file be compiled makes the code lighter and more predictable, and seems like a reasonable setup step, especially for our intended use case.

Also exposes `read_file`, which takes in a path and a dict of Earthmover config. This is the primitive that `read_compiled_source` uses. We could leave it out of the init file but callers would still be able to use it if they wanted to.

Open to other file naming / organization.

You can test the functionality out with something like this:

```python
# reader_demo.py

import logging
import os
import subprocess
import sys

import earthmover

REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
PROJECT_DIR = os.path.join(REPO_ROOT, "example_projects", "11_composition")
COMPILED = os.path.join(PROJECT_DIR, "earthmover_compiled.yaml")


def compile_project():
    """Install packages and compile, so earthmover_compiled.yaml is up to date."""
    # Ensure the subprocess can import earthmover when run from a source checkout.
    env = {**os.environ, "PYTHONPATH": os.pathsep.join([REPO_ROOT, os.environ.get("PYTHONPATH", "")])}
    for command in ("deps", "compile"):
        subprocess.run(
            [sys.executable, "-m", "earthmover", command],
            cwd=PROJECT_DIR, env=env, check=True,
        )


if __name__ == "__main__":
    logging.basicConfig(level=logging.INFO)
    logger = logging.getLogger("demo")
    compile_project()
    # `schools` is defined in the project; `students_anytown` comes from a package --
    # both are readable by name once compiled.
    for source_name in ("schools", "students_anytown"):
        df = earthmover.read_compiled_source(source_name, COMPILED, logger=logger)
        print(f"\n{source_name}: {df.shape[0]} rows x {df.shape[1]} cols")
        print(df.head().to_string(index=False))
    # read_file works too, given a path and a config dict (no project required).
    schools_csv = os.path.join(PROJECT_DIR, "sources", "schools.csv")
    df = earthmover.read_file(schools_csv, {"type": "csv", "header_rows": 1}, logger=logger)
    print(f"\nread_file(schools.csv): {df.shape[0]} rows x {df.shape[1]} cols")

```